### PR TITLE
Add basic guild-aware pages and profile editing skeleton

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,35 +4,81 @@ session_start();
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use App\Controllers\AuthController;
+use App\Controllers\ProfileController;
 
-$controller = new AuthController();
+$auth = new AuthController();
+$profile = new ProfileController();
 
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 $method = $_SERVER['REQUEST_METHOD'];
+$user = $_SESSION['user'] ?? null;
+
+$requireLogin = function () use ($user) {
+    if (!$user) {
+        header('Location: /login');
+        exit;
+    }
+};
 
 switch ($uri) {
+    case '/':
+        include __DIR__ . '/../src/views/home.php';
+        break;
     case '/login':
         if ($method === 'POST') {
-            $controller->login();
+            $auth->login();
         } else {
-            $controller->showLoginForm();
+            $auth->showLoginForm();
         }
         break;
     case '/register':
         if ($method === 'POST') {
-            $controller->register();
+            $auth->register();
         } else {
-            $controller->showRegisterForm();
+            $auth->showRegisterForm();
         }
         break;
     case '/forgot':
         if ($method === 'POST') {
-            $controller->sendResetLink();
+            $auth->sendResetLink();
         } else {
-            $controller->showForgotForm();
+            $auth->showForgotForm();
+        }
+        break;
+    case '/logout':
+        $auth->logout();
+        break;
+    case '/auctions':
+        $requireLogin();
+        include __DIR__ . '/../src/views/auctions/index.php';
+        break;
+    case '/auction-history':
+        $requireLogin();
+        include __DIR__ . '/../src/views/auctions/history.php';
+        break;
+    case '/event-history':
+        $requireLogin();
+        include __DIR__ . '/../src/views/events/history.php';
+        break;
+    case '/profile':
+        $requireLogin();
+        if ($method === 'POST') {
+            $profile->update();
+        } else {
+            $profile->show();
+        }
+        break;
+    case '/management':
+        $requireLogin();
+        if ($user['role'] === 'guild_member') {
+            http_response_code(403);
+            echo 'Forbidden';
+        } else {
+            include __DIR__ . '/../src/views/management/index.php';
         }
         break;
     default:
-        echo 'Home page';
+        http_response_code(404);
+        echo 'Not Found';
         break;
 }

--- a/src/config/permissions.php
+++ b/src/config/permissions.php
@@ -1,5 +1,7 @@
 <?php
 return [
     'admin' => ['*'],
-    'user' => ['view']
+    'guild_leader' => ['manage', 'view'],
+    'guild_advisor' => ['manage', 'view'],
+    'guild_member' => ['view']
 ];

--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -20,15 +20,17 @@ class AuthController
 
     public function login(): void
     {
+        $guild = $_POST['guild'] ?? '';
         $email = $_POST['email'] ?? '';
         $password = $_POST['password'] ?? '';
 
-        if ($this->auth->login($email, $password)) {
-            $_SESSION['user'] = $email;
-            echo "Logged in as {$email}";
-        } else {
-            $this->showLoginForm(['error' => 'Invalid credentials']);
+        $user = $this->auth->login($guild, $email, $password);
+        if ($user) {
+            $_SESSION['user'] = $user;
+            header('Location: /');
+            exit;
         }
+        $this->showLoginForm(['error' => 'Invalid credentials']);
     }
 
     public function showRegisterForm(array $data = []): void
@@ -39,16 +41,27 @@ class AuthController
 
     public function register(): void
     {
+        $guild = $_POST['guild'] ?? '';
         $email = $_POST['email'] ?? '';
         $password = $_POST['password'] ?? '';
+        $display = $_POST['display_name'] ?? '';
+        $role = $_POST['role'] ?? 'guild_member';
+        $gameRole = $_POST['game_role'] ?? '';
 
-        if (!$this->auth->register($email, $password)) {
-            $error = $email && $password ? 'User already exists' : 'Please fill in all fields';
+        if (!$this->auth->register($guild, $email, $password, $display, $role, $gameRole)) {
+            $error = $guild && $email && $password ? 'User already exists' : 'Please fill in all fields';
             $this->showRegisterForm(['error' => $error]);
             return;
         }
 
         echo 'Registration successful. <a href="/login">Login</a>';
+    }
+
+    public function logout(): void
+    {
+        session_destroy();
+        header('Location: /login');
+        exit;
     }
 
     public function showForgotForm(array $data = []): void

--- a/src/controllers/ProfileController.php
+++ b/src/controllers/ProfileController.php
@@ -1,4 +1,50 @@
 <?php
-class ProfileController {
-    // Controller logic placeholder
+namespace App\Controllers;
+
+use App\Repositories\UserRepository;
+
+class ProfileController
+{
+    private UserRepository $users;
+
+    public function __construct()
+    {
+        $this->users = new UserRepository();
+    }
+
+    public function show(): void
+    {
+        $user = $_SESSION['user'];
+        include __DIR__ . '/../views/profile/index.php';
+    }
+
+    public function update(): void
+    {
+        $user = $_SESSION['user'];
+        $display = $_POST['display_name'] ?? '';
+        $email = $_POST['email'] ?? '';
+        $gameRole = $_POST['game_role'] ?? '';
+
+        if ($email && $email !== $user['email']) {
+            $this->users->changeEmail($user['guild'], $user['email'], $email);
+            $_SESSION['user']['email'] = $email;
+            $user['email'] = $email;
+        }
+
+        $data = [];
+        if ($display) {
+            $data['display_name'] = $display;
+            $_SESSION['user']['display_name'] = $display;
+        }
+        if ($gameRole) {
+            $data['game_role'] = $gameRole;
+            $_SESSION['user']['game_role'] = $gameRole;
+        }
+
+        if ($data) {
+            $this->users->update($user['guild'], $user['email'], $data);
+        }
+
+        $this->show();
+    }
 }

--- a/src/repositories/UserRepository.php
+++ b/src/repositories/UserRepository.php
@@ -3,17 +3,40 @@ namespace App\Repositories;
 
 class UserRepository
 {
-    public function findByEmail(string $email): ?array
+    public function findByEmail(string $guild, string $email): ?array
     {
-        $users = $_SESSION['users'] ?? [];
-        return $users[$email] ?? null;
+        $guilds = $_SESSION['guilds'] ?? [];
+        return $guilds[$guild]['users'][$email] ?? null;
     }
 
-    public function create(string $email, string $password): void
+    public function create(string $guild, string $email, string $password, string $displayName, string $role, string $gameRole): void
     {
-        $users = $_SESSION['users'] ?? [];
-        $users[$email] = ['password' => $password];
-        $_SESSION['users'] = $users;
+        $guilds = $_SESSION['guilds'] ?? [];
+        $guilds[$guild]['users'][$email] = [
+            'password' => $password,
+            'display_name' => $displayName,
+            'role' => $role,
+            'game_role' => $gameRole
+        ];
+        $_SESSION['guilds'] = $guilds;
+    }
+
+    public function update(string $guild, string $email, array $data): void
+    {
+        $guilds = $_SESSION['guilds'] ?? [];
+        if (isset($guilds[$guild]['users'][$email])) {
+            $guilds[$guild]['users'][$email] = array_merge($guilds[$guild]['users'][$email], $data);
+            $_SESSION['guilds'] = $guilds;
+        }
+    }
+
+    public function changeEmail(string $guild, string $oldEmail, string $newEmail): void
+    {
+        $guilds = $_SESSION['guilds'] ?? [];
+        if (isset($guilds[$guild]['users'][$oldEmail])) {
+            $guilds[$guild]['users'][$newEmail] = $guilds[$guild]['users'][$oldEmail];
+            unset($guilds[$guild]['users'][$oldEmail]);
+            $_SESSION['guilds'] = $guilds;
+        }
     }
 }
-

--- a/src/services/AuthService.php
+++ b/src/services/AuthService.php
@@ -12,18 +12,22 @@ class AuthService
         $this->users = $users ?? new UserRepository();
     }
 
-    public function login(string $email, string $password): bool
+    public function login(string $guild, string $email, string $password): ?array
     {
-        $user = $this->users->findByEmail($email);
-        return $user && $user['password'] === $password;
+        $user = $this->users->findByEmail($guild, $email);
+        if ($user && $user['password'] === $password) {
+            unset($user['password']);
+            return $user + ['email' => $email, 'guild' => $guild];
+        }
+        return null;
     }
 
-    public function register(string $email, string $password): bool
+    public function register(string $guild, string $email, string $password, string $displayName, string $role, string $gameRole): bool
     {
-        if (!$email || !$password || $this->users->findByEmail($email)) {
+        if (!$guild || !$email || !$password || $this->users->findByEmail($guild, $email)) {
             return false;
         }
-        $this->users->create($email, $password);
+        $this->users->create($guild, $email, $password, $displayName, $role, $gameRole);
         return true;
     }
 }

--- a/src/views/auctions/history.php
+++ b/src/views/auctions/history.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Auction History</title></head>
+<body>
+<h1>Auction History</h1>
+<p>Past auctions will be listed here.</p>
+<p><a href="/">Back to home</a></p>
+</body>
+</html>

--- a/src/views/auctions/index.php
+++ b/src/views/auctions/index.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Auctions</title></head>
+<body>
+<h1>Auctions</h1>
+<p>List of active auctions will appear here.</p>
+<p><a href="/">Back to home</a></p>
+</body>
+</html>

--- a/src/views/auth/login.php
+++ b/src/views/auth/login.php
@@ -9,6 +9,7 @@
 <p style="color:red"><?= htmlspecialchars($error) ?></p>
 <?php endif; ?>
 <form method="post" action="/login">
+    <label>Guild: <input type="text" name="guild" required></label><br>
     <label>Email: <input type="email" name="email" required></label><br>
     <label>Password: <input type="password" name="password" required></label><br>
     <button type="submit">Login</button>

--- a/src/views/auth/register.php
+++ b/src/views/auth/register.php
@@ -9,8 +9,26 @@
 <p style="color:red"><?= htmlspecialchars($error) ?></p>
 <?php endif; ?>
 <form method="post" action="/register">
+    <label>Guild: <input type="text" name="guild" required></label><br>
     <label>Email: <input type="email" name="email" required></label><br>
     <label>Password: <input type="password" name="password" required></label><br>
+    <label>Display Name: <input type="text" name="display_name" required></label><br>
+    <label>Role:
+        <select name="role">
+            <option value="guild_member">Guild Member</option>
+            <option value="guild_advisor">Guild Advisor</option>
+            <option value="guild_leader">Guild Leader</option>
+            <option value="admin">Admin</option>
+        </select>
+    </label><br>
+    <label>In-game Role:
+        <select name="game_role">
+            <option value="tank">Tank</option>
+            <option value="dps">DPS</option>
+            <option value="ranged dps">Ranged DPS</option>
+            <option value="healer">Healer</option>
+        </select>
+    </label><br>
     <button type="submit">Register</button>
 </form>
 <p><a href="/login">Back to login</a></p>

--- a/src/views/events/history.php
+++ b/src/views/events/history.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Event History</title></head>
+<body>
+<h1>Event History</h1>
+<p>Past events will be listed here.</p>
+<p><a href="/">Back to home</a></p>
+</body>
+</html>

--- a/src/views/home.php
+++ b/src/views/home.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>DKP Home</title>
+</head>
+<body>
+<?php if (!empty($_SESSION['user'])): $u = $_SESSION['user']; ?>
+    <h1>Welcome, <?= htmlspecialchars($u['display_name']) ?></h1>
+    <p>This site tracks guild activity points and loot auctions.</p>
+    <nav>
+        <a href="/">Home</a> |
+        <a href="/auctions">Auctions</a> |
+        <a href="/auction-history">Auction History</a> |
+        <a href="/event-history">Event History</a> |
+        <a href="/profile">Profile</a>
+        <?php if ($u['role'] !== 'guild_member'): ?> |
+            <a href="/management">Management</a>
+        <?php endif; ?> |
+        <a href="/logout">Logout</a>
+    </nav>
+    <p>Use the navigation links above to manage your guild.</p>
+<?php else: ?>
+    <h1>DKP Site</h1>
+    <p>Please <a href="/login">login</a> or <a href="/register">register</a>.</p>
+<?php endif; ?>
+</body>
+</html>

--- a/src/views/management/index.php
+++ b/src/views/management/index.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Management</title></head>
+<body>
+<h1>Management</h1>
+<p>Placeholder for auctions, events, and user controls.</p>
+<p><a href="/">Back to home</a></p>
+</body>
+</html>

--- a/src/views/profile/index.php
+++ b/src/views/profile/index.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head><title>Profile</title></head>
+<body>
+<h1>Profile</h1>
+<form method="post" action="/profile">
+    <label>Email: <input type="email" name="email" value="<?= htmlspecialchars($user['email']) ?>" required></label><br>
+    <p>Guild: <?= htmlspecialchars($user['guild']) ?></p>
+    <p>Role: <?= htmlspecialchars($user['role']) ?></p>
+    <label>Display Name: <input type="text" name="display_name" value="<?= htmlspecialchars($user['display_name']) ?>" required></label><br>
+    <label>In-game Role:
+        <select name="game_role">
+            <?php $roles = ['tank'=>'Tank','dps'=>'DPS','ranged dps'=>'Ranged DPS','healer'=>'Healer']; foreach($roles as $value=>$label): ?>
+            <option value="<?= $value ?>"<?= $user['game_role']===$value?' selected':'' ?>><?= $label ?></option>
+            <?php endforeach; ?>
+        </select>
+    </label><br>
+    <button type="submit">Save</button>
+</form>
+<p><a href="/">Back to home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support multiple guilds with roles (admin, leader, advisor, member)
- add registration and login fields for guild, role and in-game role
- implement placeholder home, auction, history, event, profile and management pages
- allow members to edit email, display name and game role in profile

## Testing
- `php -l public/index.php`
- `php -l src/config/permissions.php`
- `php -l src/controllers/AuthController.php`
- `php -l src/controllers/ProfileController.php`
- `php -l src/repositories/UserRepository.php`
- `php -l src/services/AuthService.php`
- `php -l src/views/auth/login.php`
- `php -l src/views/auth/register.php`
- `php -l src/views/auctions/index.php`
- `php -l src/views/auctions/history.php`
- `php -l src/views/events/history.php`
- `php -l src/views/home.php`
- `php -l src/views/management/index.php`
- `php -l src/views/profile/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689d9d861714832c814285609ebac4a1