### PR TITLE
Add CSRF protection to auth forms

### DIFF
--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -2,6 +2,7 @@
 namespace App\Controllers;
 
 use App\Services\AuthService;
+use App\Helpers\Csrf;
 
 class AuthController
 {
@@ -20,6 +21,11 @@ class AuthController
 
     public function login(): void
     {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            echo 'Invalid CSRF token';
+            return;
+        }
         $guild = $_POST['guild'] ?? '';
         $email = $_POST['email'] ?? '';
         $password = $_POST['password'] ?? '';
@@ -41,6 +47,11 @@ class AuthController
 
     public function register(): void
     {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            echo 'Invalid CSRF token';
+            return;
+        }
         $guild = $_POST['guild'] ?? '';
         $email = $_POST['email'] ?? '';
         $password = $_POST['password'] ?? '';
@@ -72,6 +83,11 @@ class AuthController
 
     public function sendResetLink(): void
     {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            echo 'Invalid CSRF token';
+            return;
+        }
         $email = $_POST['email'] ?? '';
         $message = 'If the email is registered, a reset link has been sent.';
         $this->showForgotForm(['message' => $message]);

--- a/src/helpers/Csrf.php
+++ b/src/helpers/Csrf.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Helpers;
+
+class Csrf
+{
+    public static function generateToken(): string
+    {
+        if (empty($_SESSION['csrf_token'])) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
+        return $_SESSION['csrf_token'];
+    }
+
+    public static function validateToken(string $token): bool
+    {
+        return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+    }
+
+    public static function inputField(): string
+    {
+        $token = self::generateToken();
+        return '<input type="hidden" name="csrf_token" value="' . htmlspecialchars($token, ENT_QUOTES, 'UTF-8') . '">';
+    }
+}

--- a/src/views/auth/forgot.php
+++ b/src/views/auth/forgot.php
@@ -9,6 +9,7 @@
 <p><?= htmlspecialchars($message) ?></p>
 <?php endif; ?>
 <form method="post" action="/forgot">
+    <?= \App\Helpers\Csrf::inputField() ?>
     <label>Email: <input type="email" name="email" required></label><br>
     <button type="submit">Send reset link</button>
 </form>

--- a/src/views/auth/login.php
+++ b/src/views/auth/login.php
@@ -9,6 +9,7 @@
 <p style="color:red"><?= htmlspecialchars($error) ?></p>
 <?php endif; ?>
 <form method="post" action="/login">
+    <?= \App\Helpers\Csrf::inputField() ?>
     <label>Guild: <input type="text" name="guild" required></label><br>
     <label>Email: <input type="email" name="email" required></label><br>
     <label>Password: <input type="password" name="password" required></label><br>

--- a/src/views/auth/register.php
+++ b/src/views/auth/register.php
@@ -9,6 +9,7 @@
 <p style="color:red"><?= htmlspecialchars($error) ?></p>
 <?php endif; ?>
 <form method="post" action="/register">
+    <?= \App\Helpers\Csrf::inputField() ?>
     <label>Guild: <input type="text" name="guild" required></label><br>
     <label>Email: <input type="email" name="email" required></label><br>
     <label>Password: <input type="password" name="password" required></label><br>


### PR DESCRIPTION
## Summary
- Add Csrf helper to generate, embed, and validate CSRF tokens
- Include hidden token fields in login, register, and forgot password forms
- Validate CSRF tokens in AuthController actions before processing

## Testing
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689da1842f98832c896567c95eaaa19b