### PR TITLE
Use hashed passwords in session auth

### DIFF
--- a/src/repositories/UserRepository.php
+++ b/src/repositories/UserRepository.php
@@ -9,11 +9,11 @@ class UserRepository
         return $guilds[$guild]['users'][$email] ?? null;
     }
 
-    public function create(string $guild, string $email, string $password, string $displayName, string $role, string $gameRole): void
+    public function create(string $guild, string $email, string $passwordHash, string $displayName, string $role, string $gameRole): void
     {
         $guilds = $_SESSION['guilds'] ?? [];
         $guilds[$guild]['users'][$email] = [
-            'password' => $password,
+            'password' => $passwordHash,
             'display_name' => $displayName,
             'role' => $role,
             'game_role' => $gameRole

--- a/src/services/AuthService.php
+++ b/src/services/AuthService.php
@@ -15,7 +15,7 @@ class AuthService
     public function login(string $guild, string $email, string $password): ?array
     {
         $user = $this->users->findByEmail($guild, $email);
-        if ($user && $user['password'] === $password) {
+        if ($user && password_verify($password, $user['password'])) {
             unset($user['password']);
             return $user + ['email' => $email, 'guild' => $guild];
         }
@@ -27,7 +27,8 @@ class AuthService
         if (!$guild || !$email || !$password || $this->users->findByEmail($guild, $email)) {
             return false;
         }
-        $this->users->create($guild, $email, $password, $displayName, $role, $gameRole);
+        $passwordHash = password_hash($password, PASSWORD_DEFAULT);
+        $this->users->create($guild, $email, $passwordHash, $displayName, $role, $gameRole);
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- verify login with `password_verify`
- hash passwords on registration and store in repository

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da184905c832c9728e505767abab1