### PR TITLE
Add reusable layout and apply across views

### DIFF
--- a/src/views/auctions/history.php
+++ b/src/views/auctions/history.php
@@ -1,9 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head><title>Auction History</title></head>
-<body>
+<?php
+$title = 'Auction History';
+$currentPage = 'auction-history';
+ob_start();
+?>
 <h1>Auction History</h1>
 <p>Past auctions will be listed here.</p>
-<p><a href="/">Back to home</a></p>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/auctions/index.php
+++ b/src/views/auctions/index.php
@@ -1,9 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head><title>Auctions</title></head>
-<body>
+<?php
+$title = 'Auctions';
+$currentPage = 'auctions';
+ob_start();
+?>
 <h1>Auctions</h1>
 <p>List of active auctions will appear here.</p>
-<p><a href="/">Back to home</a></p>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/auth/forgot.php
+++ b/src/views/auth/forgot.php
@@ -1,9 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Forgot Password</title>
-</head>
-<body>
+<?php
+$title = 'Forgot Password';
+$currentPage = 'forgot';
+ob_start();
+?>
 <h1>Forgot Password</h1>
 <?php if (!empty($message)): ?>
 <p><?= htmlspecialchars($message) ?></p>
@@ -14,5 +13,6 @@
     <button type="submit">Send reset link</button>
 </form>
 <p><a href="/login">Back to login</a></p>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/auth/login.php
+++ b/src/views/auth/login.php
@@ -1,9 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Login</title>
-</head>
-<body>
+<?php
+$title = 'Login';
+$currentPage = 'login';
+ob_start();
+?>
 <h1>Login</h1>
 <?php if (!empty($error)): ?>
 <p style="color:red"><?= htmlspecialchars($error) ?></p>
@@ -16,5 +15,6 @@
     <button type="submit">Login</button>
 </form>
 <p><a href="/register">Register</a> | <a href="/forgot">Forgot password?</a></p>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/auth/register.php
+++ b/src/views/auth/register.php
@@ -1,9 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Register</title>
-</head>
-<body>
+<?php
+$title = 'Register';
+$currentPage = 'register';
+ob_start();
+?>
 <h1>Register</h1>
 <?php if (!empty($error)): ?>
 <p style="color:red"><?= htmlspecialchars($error) ?></p>
@@ -33,5 +32,6 @@
     <button type="submit">Register</button>
 </form>
 <p><a href="/login">Back to login</a></p>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/events/history.php
+++ b/src/views/events/history.php
@@ -1,9 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head><title>Event History</title></head>
-<body>
+<?php
+$title = 'Event History';
+$currentPage = 'event-history';
+ob_start();
+?>
 <h1>Event History</h1>
 <p>Past events will be listed here.</p>
-<p><a href="/">Back to home</a></p>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/home.php
+++ b/src/views/home.php
@@ -1,27 +1,17 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>DKP Home</title>
-</head>
-<body>
-<?php if (!empty($_SESSION['user'])): $u = $_SESSION['user']; ?>
+<?php
+$u = $_SESSION['user'] ?? null;
+$title = 'DKP Home';
+$currentPage = 'home';
+ob_start();
+?>
+<?php if (!empty($u)): ?>
     <h1>Welcome, <?= htmlspecialchars($u['display_name']) ?></h1>
     <p>This site tracks guild activity points and loot auctions.</p>
-    <nav>
-        <a href="/">Home</a> |
-        <a href="/auctions">Auctions</a> |
-        <a href="/auction-history">Auction History</a> |
-        <a href="/event-history">Event History</a> |
-        <a href="/profile">Profile</a>
-        <?php if ($u['role'] !== 'guild_member'): ?> |
-            <a href="/management">Management</a>
-        <?php endif; ?> |
-        <a href="/logout">Logout</a>
-    </nav>
     <p>Use the navigation links above to manage your guild.</p>
 <?php else: ?>
     <h1>DKP Site</h1>
     <p>Please <a href="/login">login</a> or <a href="/register">register</a>.</p>
 <?php endif; ?>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/layouts/main.php';

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -1,0 +1,46 @@
+<?php
+// Main layout for DKP Site views
+// Expected variables: \$title, \$content, \$currentPage
+// Optionally: \$user for navigation logic
+
+\$title = \$title ?? 'DKP Site';
+\$currentPage = \$currentPage ?? '';
+\$user = \$user ?? (\$_SESSION['user'] ?? null);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars(\$title) ?></title>
+    <style>
+        nav a.active {
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/" class="<?= \$currentPage === 'home' ? 'active' : '' ?>">Home</a> |
+    <a href="/auctions" class="<?= \$currentPage === 'auctions' ? 'active' : '' ?>">Auctions</a> |
+    <a href="/auction-history" class="<?= \$currentPage === 'auction-history' ? 'active' : '' ?>">Auction History</a> |
+    <a href="/event-history" class="<?= \$currentPage === 'event-history' ? 'active' : '' ?>">Event History</a> |
+    <?php if (\$user): ?>
+        <a href="/profile" class="<?= \$currentPage === 'profile' ? 'active' : '' ?>">Profile</a>
+        <?php if (\$user['role'] !== 'guild_member'): ?> |
+            <a href="/management" class="<?= \$currentPage === 'management' ? 'active' : '' ?>">Management</a>
+        <?php endif; ?> |
+        <a href="/logout">Logout</a>
+    <?php else: ?>
+        <a href="/login" class="<?= \$currentPage === 'login' ? 'active' : '' ?>">Login</a> |
+        <a href="/register" class="<?= \$currentPage === 'register' ? 'active' : '' ?>">Register</a>
+    <?php endif; ?>
+</nav>
+<main>
+    <?= \$content ?? '' ?>
+</main>
+<footer>
+    <p>&copy; <?= date('Y') ?> DKP Site</p>
+</footer>
+</body>
+</html>

--- a/src/views/management/index.php
+++ b/src/views/management/index.php
@@ -1,9 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head><title>Management</title></head>
-<body>
+<?php
+$title = 'Management';
+$currentPage = 'management';
+ob_start();
+?>
 <h1>Management</h1>
 <p>Placeholder for auctions, events, and user controls.</p>
-<p><a href="/">Back to home</a></p>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/profile/index.php
+++ b/src/views/profile/index.php
@@ -1,7 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head><title>Profile</title></head>
-<body>
+<?php
+$title = 'Profile';
+$currentPage = 'profile';
+ob_start();
+?>
 <h1>Profile</h1>
 <form method="post" action="/profile">
     <label>Email: <input type="email" name="email" value="<?= htmlspecialchars($user['email']) ?>" required></label><br>
@@ -10,13 +11,13 @@
     <label>Display Name: <input type="text" name="display_name" value="<?= htmlspecialchars($user['display_name']) ?>" required></label><br>
     <label>In-game Role:
         <select name="game_role">
-            <?php $roles = ['tank'=>'Tank','dps'=>'DPS','ranged dps'=>'Ranged DPS','healer'=>'Healer']; foreach($roles as $value=>$label): ?>
+            <?php $roles = ['tank'=>'Tank','dps'=>'DPS','ranged dps'=>'Ranged DPS','healer'=>'Healer']; foreach($roles as $value=> $label): ?>
             <option value="<?= $value ?>"<?= $user['game_role']===$value?' selected':'' ?>><?= $label ?></option>
             <?php endforeach; ?>
         </select>
     </label><br>
     <button type="submit">Save</button>
 </form>
-<p><a href="/">Back to home</a></p>
-</body>
-</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';


### PR DESCRIPTION
## Summary
- Add centralized main layout with metadata, nav bar, and footer
- Refactor all views to render through the shared layout
- Highlight active page and hide management link for non-authorized users

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689da583a74c832c882eafef3c0f7cd8