### PR TITLE
Implement data-driven listings with pagination

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -5,9 +5,15 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use App\Controllers\AuthController;
 use App\Controllers\ProfileController;
+use App\Controllers\AuctionController;
+use App\Controllers\EventController;
+use App\Controllers\ManagementController;
 
 $auth = new AuthController();
 $profile = new ProfileController();
+$auction = new AuctionController();
+$event = new EventController();
+$management = new ManagementController();
 
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 $method = $_SERVER['REQUEST_METHOD'];

--- a/src/controllers/AuctionController.php
+++ b/src/controllers/AuctionController.php
@@ -1,4 +1,35 @@
 <?php
-class AuctionController {
-    // Controller logic placeholder
+namespace App\Controllers;
+
+use App\Repositories\AuctionRepository;
+
+class AuctionController
+{
+    private AuctionRepository $auctions;
+
+    public function __construct()
+    {
+        $this->auctions = new AuctionRepository();
+    }
+
+    public function index(): void
+    {
+        $page = max(1, (int)($_GET['page'] ?? 1));
+        $sort = $_GET['sort'] ?? 'id';
+        $dir = $_GET['dir'] ?? 'asc';
+        $perPage = 10;
+
+        $items = $this->auctions->all();
+        usort($items, function ($a, $b) use ($sort, $dir) {
+            return $dir === 'asc' ? $a[$sort] <=> $b[$sort] : $b[$sort] <=> $a[$sort];
+        });
+
+        $total = count($items);
+        $pages = max(1, (int)ceil($total / $perPage));
+        $page = min($page, $pages);
+        $offset = ($page - 1) * $perPage;
+        $items = array_slice($items, $offset, $perPage);
+
+        include __DIR__ . '/../views/auctions/index.php';
+    }
 }

--- a/src/controllers/EventController.php
+++ b/src/controllers/EventController.php
@@ -1,4 +1,35 @@
 <?php
-class EventController {
-    // Controller logic placeholder
+namespace App\Controllers;
+
+use App\Repositories\EventRepository;
+
+class EventController
+{
+    private EventRepository $events;
+
+    public function __construct()
+    {
+        $this->events = new EventRepository();
+    }
+
+    public function history(): void
+    {
+        $page = max(1, (int)($_GET['page'] ?? 1));
+        $sort = $_GET['sort'] ?? 'date';
+        $dir = $_GET['dir'] ?? 'desc';
+        $perPage = 10;
+
+        $items = $this->events->all();
+        usort($items, function ($a, $b) use ($sort, $dir) {
+            return $dir === 'asc' ? $a[$sort] <=> $b[$sort] : $b[$sort] <=> $a[$sort];
+        });
+
+        $total = count($items);
+        $pages = max(1, (int)ceil($total / $perPage));
+        $page = min($page, $pages);
+        $offset = ($page - 1) * $perPage;
+        $items = array_slice($items, $offset, $perPage);
+
+        include __DIR__ . '/../views/events/history.php';
+    }
 }

--- a/src/controllers/ManagementController.php
+++ b/src/controllers/ManagementController.php
@@ -1,4 +1,51 @@
 <?php
-class ManagementController {
-    // Controller logic placeholder
+namespace App\Controllers;
+
+use App\Repositories\AuctionRepository;
+use App\Repositories\EventRepository;
+
+class ManagementController
+{
+    private AuctionRepository $auctions;
+    private EventRepository $events;
+
+    public function __construct()
+    {
+        $this->auctions = new AuctionRepository();
+        $this->events = new EventRepository();
+    }
+
+    public function index(): void
+    {
+        // Auctions
+        $auctionPage = max(1, (int)($_GET['auction_page'] ?? 1));
+        $auctionSort = $_GET['auction_sort'] ?? 'id';
+        $auctionDir = $_GET['auction_dir'] ?? 'asc';
+
+        $perPage = 5;
+        $auctionItems = $this->auctions->all();
+        usort($auctionItems, function ($a, $b) use ($auctionSort, $auctionDir) {
+            return $auctionDir === 'asc' ? $a[$auctionSort] <=> $b[$auctionSort] : $b[$auctionSort] <=> $a[$auctionSort];
+        });
+        $auctionTotal = count($auctionItems);
+        $auctionPages = max(1, (int)ceil($auctionTotal / $perPage));
+        $auctionPage = min($auctionPage, $auctionPages);
+        $auctionItems = array_slice($auctionItems, ($auctionPage - 1) * $perPage, $perPage);
+
+        // Events
+        $eventPage = max(1, (int)($_GET['event_page'] ?? 1));
+        $eventSort = $_GET['event_sort'] ?? 'date';
+        $eventDir = $_GET['event_dir'] ?? 'desc';
+
+        $eventItems = $this->events->all();
+        usort($eventItems, function ($a, $b) use ($eventSort, $eventDir) {
+            return $eventDir === 'asc' ? $a[$eventSort] <=> $b[$eventSort] : $b[$eventSort] <=> $a[$eventSort];
+        });
+        $eventTotal = count($eventItems);
+        $eventPages = max(1, (int)ceil($eventTotal / $perPage));
+        $eventPage = min($eventPage, $eventPages);
+        $eventItems = array_slice($eventItems, ($eventPage - 1) * $perPage, $perPage);
+
+        include __DIR__ . '/../views/management/index.php';
+    }
 }

--- a/src/repositories/AuctionRepository.php
+++ b/src/repositories/AuctionRepository.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Repositories;
+
+class AuctionRepository
+{
+    public function all(): array
+    {
+        $auctions = $_SESSION['auctions'] ?? [];
+        if (!$auctions) {
+            for ($i = 1; $i <= 25; $i++) {
+                $auctions[] = [
+                    'id' => $i,
+                    'item' => 'Item ' . $i,
+                    'status' => $i % 2 ? 'open' : 'closed',
+                    'created_at' => date('Y-m-d', strtotime("-{$i} days"))
+                ];
+            }
+            $_SESSION['auctions'] = $auctions;
+        }
+        return $auctions;
+    }
+}

--- a/src/repositories/EventRepository.php
+++ b/src/repositories/EventRepository.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Repositories;
+
+class EventRepository
+{
+    public function all(): array
+    {
+        $events = $_SESSION['events'] ?? [];
+        if (!$events) {
+            for ($i = 1; $i <= 30; $i++) {
+                $events[] = [
+                    'id' => $i,
+                    'name' => 'Event ' . $i,
+                    'date' => date('Y-m-d', strtotime("-{$i} days"))
+                ];
+            }
+            $_SESSION['events'] = $events;
+        }
+        return $events;
+    }
+}

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -22,9 +22,9 @@ return [
         'GET' => [$auth, 'logout'],
     ],
     '/auctions' => [
-        'GET' => function () use ($requireLogin) {
+        'GET' => function () use ($requireLogin, $auction) {
             $requireLogin();
-            include __DIR__ . '/../views/auctions/index.php';
+            $auction->index();
         },
     ],
     '/auction-history' => [
@@ -34,9 +34,9 @@ return [
         },
     ],
     '/event-history' => [
-        'GET' => function () use ($requireLogin) {
+        'GET' => function () use ($requireLogin, $event) {
             $requireLogin();
-            include __DIR__ . '/../views/events/history.php';
+            $event->history();
         },
     ],
     '/profile' => [
@@ -50,13 +50,13 @@ return [
         },
     ],
     '/management' => [
-        'GET' => function () use ($requireLogin, $user) {
+        'GET' => function () use ($requireLogin, $user, $management) {
             $requireLogin();
             if ($user['role'] === 'guild_member') {
                 http_response_code(403);
                 echo 'Forbidden';
             } else {
-                include __DIR__ . '/../views/management/index.php';
+                $management->index();
             }
         },
     ],

--- a/src/views/auctions/index.php
+++ b/src/views/auctions/index.php
@@ -4,7 +4,35 @@ $currentPage = 'auctions';
 ob_start();
 ?>
 <h1>Auctions</h1>
-<p>List of active auctions will appear here.</p>
+<table>
+    <thead>
+        <tr>
+            <th><a href="?sort=id&dir=<?= $sort === 'id' && $dir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
+            <th><a href="?sort=item&dir=<?= $sort === 'item' && $dir === 'asc' ? 'desc' : 'asc' ?>">Item</a></th>
+            <th><a href="?sort=status&dir=<?= $sort === 'status' && $dir === 'asc' ? 'desc' : 'asc' ?>">Status</a></th>
+            <th><a href="?sort=created_at&dir=<?= $sort === 'created_at' && $dir === 'asc' ? 'desc' : 'asc' ?>">Created</a></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($items as $auction): ?>
+        <tr>
+            <td><?= htmlspecialchars($auction['id']) ?></td>
+            <td><?= htmlspecialchars($auction['item']) ?></td>
+            <td><?= htmlspecialchars($auction['status']) ?></td>
+            <td><?= htmlspecialchars($auction['created_at']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<div class="pagination">
+    <?php if ($page > 1): ?>
+        <a href="?page=<?= $page-1 ?>&sort=<?= $sort ?>&dir=<?= $dir ?>">Prev</a>
+    <?php endif; ?>
+    Page <?= $page ?> of <?= $pages ?>
+    <?php if ($page < $pages): ?>
+        <a href="?page=<?= $page+1 ?>&sort=<?= $sort ?>&dir=<?= $dir ?>">Next</a>
+    <?php endif; ?>
+</div>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../layouts/main.php';

--- a/src/views/events/history.php
+++ b/src/views/events/history.php
@@ -4,7 +4,33 @@ $currentPage = 'event-history';
 ob_start();
 ?>
 <h1>Event History</h1>
-<p>Past events will be listed here.</p>
+<table>
+    <thead>
+        <tr>
+            <th><a href="?sort=id&dir=<?= $sort === 'id' && $dir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
+            <th><a href="?sort=name&dir=<?= $sort === 'name' && $dir === 'asc' ? 'desc' : 'asc' ?>">Name</a></th>
+            <th><a href="?sort=date&dir=<?= $sort === 'date' && $dir === 'asc' ? 'desc' : 'asc' ?>">Date</a></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($items as $event): ?>
+        <tr>
+            <td><?= htmlspecialchars($event['id']) ?></td>
+            <td><?= htmlspecialchars($event['name']) ?></td>
+            <td><?= htmlspecialchars($event['date']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<div class="pagination">
+    <?php if ($page > 1): ?>
+        <a href="?page=<?= $page-1 ?>&sort=<?= $sort ?>&dir=<?= $dir ?>">Prev</a>
+    <?php endif; ?>
+    Page <?= $page ?> of <?= $pages ?>
+    <?php if ($page < $pages): ?>
+        <a href="?page=<?= $page+1 ?>&sort=<?= $sort ?>&dir=<?= $dir ?>">Next</a>
+    <?php endif; ?>
+</div>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../layouts/main.php';

--- a/src/views/management/index.php
+++ b/src/views/management/index.php
@@ -4,7 +4,64 @@ $currentPage = 'management';
 ob_start();
 ?>
 <h1>Management</h1>
-<p>Placeholder for auctions, events, and user controls.</p>
+
+<h2>Auctions</h2>
+<table>
+    <thead>
+        <tr>
+            <th><a href="?auction_sort=id&auction_dir=<?= $auctionSort === 'id' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
+            <th><a href="?auction_sort=item&auction_dir=<?= $auctionSort === 'item' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">Item</a></th>
+            <th><a href="?auction_sort=status&auction_dir=<?= $auctionSort === 'status' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">Status</a></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($auctionItems as $auction): ?>
+        <tr>
+            <td><?= htmlspecialchars($auction['id']) ?></td>
+            <td><?= htmlspecialchars($auction['item']) ?></td>
+            <td><?= htmlspecialchars($auction['status']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<div class="pagination">
+    <?php if ($auctionPage > 1): ?>
+        <a href="?auction_page=<?= $auctionPage-1 ?>&auction_sort=<?= $auctionSort ?>&auction_dir=<?= $auctionDir ?>">Prev</a>
+    <?php endif; ?>
+    Page <?= $auctionPage ?> of <?= $auctionPages ?>
+    <?php if ($auctionPage < $auctionPages): ?>
+        <a href="?auction_page=<?= $auctionPage+1 ?>&auction_sort=<?= $auctionSort ?>&auction_dir=<?= $auctionDir ?>">Next</a>
+    <?php endif; ?>
+</div>
+
+<h2>Events</h2>
+<table>
+    <thead>
+        <tr>
+            <th><a href="?event_sort=id&event_dir=<?= $eventSort === 'id' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
+            <th><a href="?event_sort=name&event_dir=<?= $eventSort === 'name' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">Name</a></th>
+            <th><a href="?event_sort=date&event_dir=<?= $eventSort === 'date' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">Date</a></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($eventItems as $event): ?>
+        <tr>
+            <td><?= htmlspecialchars($event['id']) ?></td>
+            <td><?= htmlspecialchars($event['name']) ?></td>
+            <td><?= htmlspecialchars($event['date']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<div class="pagination">
+    <?php if ($eventPage > 1): ?>
+        <a href="?event_page=<?= $eventPage-1 ?>&event_sort=<?= $eventSort ?>&event_dir=<?= $eventDir ?>">Prev</a>
+    <?php endif; ?>
+    Page <?= $eventPage ?> of <?= $eventPages ?>
+    <?php if ($eventPage < $eventPages): ?>
+        <a href="?event_page=<?= $eventPage+1 ?>&event_sort=<?= $eventSort ?>&event_dir=<?= $eventDir ?>">Next</a>
+    <?php endif; ?>
+</div>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../layouts/main.php';


### PR DESCRIPTION
## Summary
- Replace placeholder views for auctions, events, and management with sortable, paginated tables fed from controller data.
- Add repositories and controllers to supply auction and event records to views.
- Wire new controllers into routing and front controller for data-driven pages.

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689db80ae30c832cadc817290f288503