### PR TITLE
Default new registrations to guild member role

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Skeleton project structure with basic authentication flow.
 
 The front controller (`public/index.php`) now uses Composer's PSR-4 autoloader to load
 namespaced classes from `src/`.
+
+## Roles
+
+All users register as `guild_member`. Elevated roles such as `guild_advisor`, `guild_leader`, or `admin` must be granted by an administrator after registration. A privileged user can promote members by updating their role through the management tooling or by calling `UserRepository::update` in custom workflows.

--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -81,7 +81,7 @@ class AuthController
         $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
         $display = trim($_POST['display_name'] ?? '');
-        $role = $_POST['role'] ?? 'guild_member';
+        $role = 'guild_member'; // Elevated roles must be granted by an administrator
         $gameRole = $_POST['game_role'] ?? '';
 
         $errors = [];
@@ -97,9 +97,6 @@ class AuthController
         if ($display === '') {
             $errors['display_name'] = 'Display name is required';
         }
-        if ($role === '') {
-            $errors['role'] = 'Role is required';
-        }
         if ($gameRole === '') {
             $errors['game_role'] = 'In-game role is required';
         }
@@ -111,7 +108,6 @@ class AuthController
                     'guild' => $guild,
                     'email' => $email,
                     'display_name' => $display,
-                    'role' => $role,
                     'game_role' => $gameRole
                 ]
             ]);
@@ -125,7 +121,6 @@ class AuthController
                     'guild' => $guild,
                     'email' => $email,
                     'display_name' => $display,
-                    'role' => $role,
                     'game_role' => $gameRole
                 ]
             ]);

--- a/src/views/auth/register.php
+++ b/src/views/auth/register.php
@@ -22,15 +22,6 @@ ob_start();
         <input type="text" name="display_name" value="<?= htmlspecialchars($values['display_name'] ?? '') ?>" required>
     </label>
     <span class="error" data-error="display_name" style="color:red"><?= htmlspecialchars($errors['display_name'] ?? '') ?></span><br>
-    <label>Role:
-        <select name="role">
-            <option value="guild_member" <?= ($values['role'] ?? '') === 'guild_member' ? 'selected' : '' ?>>Guild Member</option>
-            <option value="guild_advisor" <?= ($values['role'] ?? '') === 'guild_advisor' ? 'selected' : '' ?>>Guild Advisor</option>
-            <option value="guild_leader" <?= ($values['role'] ?? '') === 'guild_leader' ? 'selected' : '' ?>>Guild Leader</option>
-            <option value="admin" <?= ($values['role'] ?? '') === 'admin' ? 'selected' : '' ?>>Admin</option>
-        </select>
-    </label>
-    <span class="error" data-error="role" style="color:red"><?= htmlspecialchars($errors['role'] ?? '') ?></span><br>
     <label>In-game Role:
         <select name="game_role">
             <option value="tank" <?= ($values['game_role'] ?? '') === 'tank' ? 'selected' : '' ?>>Tank</option>
@@ -46,7 +37,7 @@ ob_start();
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('registerForm');
-    const fields = ['guild', 'email', 'password', 'display_name', 'role', 'game_role'];
+    const fields = ['guild', 'email', 'password', 'display_name', 'game_role'];
 
     const validateField = (field) => {
         const input = form[field];


### PR DESCRIPTION
## Summary
- Remove role selector from registration form so users sign up only as standard members
- Force AuthController to assign `guild_member` on registration and drop role validation
- Document that elevated roles are granted by administrators after sign‑up

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689dbb53eac4832cae27ab3ef7e686a2