### PR TITLE
Improve accessibility and semantics for DKP Site forms

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -4,6 +4,8 @@
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
+    background-color: #fff;
+    color: #000;
 }
 
 .site-nav {
@@ -15,6 +17,13 @@
     color: #fff;
     margin-right: 0.5rem;
     text-decoration: none;
+}
+
+.site-nav a:focus,
+.site-nav a:hover {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+    text-decoration: underline;
 }
 
 .site-nav a.active {
@@ -29,4 +38,24 @@
     text-align: center;
     padding: 1rem;
     background-color: #f4f4f4;
+}
+
+button {
+    background-color: #0069d9;
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+}
+
+button:hover,
+button:focus {
+    background-color: #0053ba;
+}
+
+button:focus,
+input:focus,
+select:focus {
+    outline: 2px solid #000;
+    outline-offset: 2px;
 }

--- a/src/views/auth/forgot.php
+++ b/src/views/auth/forgot.php
@@ -9,7 +9,8 @@ ob_start();
 <?php endif; ?>
 <form method="post" action="/forgot">
     <?= \App\Helpers\Csrf::inputField() ?>
-    <label>Email: <input type="email" name="email" required></label><br>
+    <label for="forgot-email">Email:</label>
+    <input type="email" id="forgot-email" name="email" required><br>
     <button type="submit">Send reset link</button>
 </form>
 <p><a href="/login">Back to login</a></p>

--- a/src/views/auth/login.php
+++ b/src/views/auth/login.php
@@ -9,18 +9,18 @@ ob_start();
 <?php endif; ?>
 <form method="post" action="/login" id="loginForm" novalidate>
     <?= \App\Helpers\Csrf::inputField() ?>
-    <label>Guild:
-        <input type="text" name="guild" value="<?= htmlspecialchars($values['guild'] ?? '') ?>" required>
-    </label>
+    <label for="login-guild">Guild:</label>
+    <input type="text" id="login-guild" name="guild" value="<?= htmlspecialchars($values['guild'] ?? '') ?>" required>
     <span class="error" data-error="guild" style="color:red"><?= htmlspecialchars($errors['guild'] ?? '') ?></span><br>
-    <label>Email:
-        <input type="email" name="email" value="<?= htmlspecialchars($values['email'] ?? '') ?>" required>
-    </label>
+
+    <label for="login-email">Email:</label>
+    <input type="email" id="login-email" name="email" value="<?= htmlspecialchars($values['email'] ?? '') ?>" required>
     <span class="error" data-error="email" style="color:red"><?= htmlspecialchars($errors['email'] ?? '') ?></span><br>
-    <label>Password:
-        <input type="password" name="password" required>
-    </label>
+
+    <label for="login-password">Password:</label>
+    <input type="password" id="login-password" name="password" required>
     <span class="error" data-error="password" style="color:red"><?= htmlspecialchars($errors['password'] ?? '') ?></span><br>
+
     <button type="submit">Login</button>
 </form>
 <p><a href="/register">Register</a> | <a href="/forgot">Forgot password?</a></p>

--- a/src/views/auth/register.php
+++ b/src/views/auth/register.php
@@ -6,31 +6,31 @@ ob_start();
 <h1>Register</h1>
 <form method="post" action="/register" id="registerForm" novalidate>
     <?= \App\Helpers\Csrf::inputField() ?>
-    <label>Guild:
-        <input type="text" name="guild" value="<?= htmlspecialchars($values['guild'] ?? '') ?>" required>
-    </label>
+    <label for="register-guild">Guild:</label>
+    <input type="text" id="register-guild" name="guild" value="<?= htmlspecialchars($values['guild'] ?? '') ?>" required>
     <span class="error" data-error="guild" style="color:red"><?= htmlspecialchars($errors['guild'] ?? '') ?></span><br>
-    <label>Email:
-        <input type="email" name="email" value="<?= htmlspecialchars($values['email'] ?? '') ?>" required>
-    </label>
+
+    <label for="register-email">Email:</label>
+    <input type="email" id="register-email" name="email" value="<?= htmlspecialchars($values['email'] ?? '') ?>" required>
     <span class="error" data-error="email" style="color:red"><?= htmlspecialchars($errors['email'] ?? '') ?></span><br>
-    <label>Password:
-        <input type="password" name="password" required>
-    </label>
+
+    <label for="register-password">Password:</label>
+    <input type="password" id="register-password" name="password" required>
     <span class="error" data-error="password" style="color:red"><?= htmlspecialchars($errors['password'] ?? '') ?></span><br>
-    <label>Display Name:
-        <input type="text" name="display_name" value="<?= htmlspecialchars($values['display_name'] ?? '') ?>" required>
-    </label>
+
+    <label for="register-display-name">Display Name:</label>
+    <input type="text" id="register-display-name" name="display_name" value="<?= htmlspecialchars($values['display_name'] ?? '') ?>" required>
     <span class="error" data-error="display_name" style="color:red"><?= htmlspecialchars($errors['display_name'] ?? '') ?></span><br>
-    <label>In-game Role:
-        <select name="game_role">
-            <option value="tank" <?= ($values['game_role'] ?? '') === 'tank' ? 'selected' : '' ?>>Tank</option>
-            <option value="dps" <?= ($values['game_role'] ?? '') === 'dps' ? 'selected' : '' ?>>DPS</option>
-            <option value="ranged dps" <?= ($values['game_role'] ?? '') === 'ranged dps' ? 'selected' : '' ?>>Ranged DPS</option>
-            <option value="healer" <?= ($values['game_role'] ?? '') === 'healer' ? 'selected' : '' ?>>Healer</option>
-        </select>
-    </label>
+
+    <label for="register-game-role">In-game Role:</label>
+    <select id="register-game-role" name="game_role">
+        <option value="tank" <?= ($values['game_role'] ?? '') === 'tank' ? 'selected' : '' ?>>Tank</option>
+        <option value="dps" <?= ($values['game_role'] ?? '') === 'dps' ? 'selected' : '' ?>>DPS</option>
+        <option value="ranged dps" <?= ($values['game_role'] ?? '') === 'ranged dps' ? 'selected' : '' ?>>Ranged DPS</option>
+        <option value="healer" <?= ($values['game_role'] ?? '') === 'healer' ? 'selected' : '' ?>>Healer</option>
+    </select>
     <span class="error" data-error="game_role" style="color:red"><?= htmlspecialchars($errors['game_role'] ?? '') ?></span><br>
+
     <button type="submit">Register</button>
 </form>
 <p><a href="/login">Back to login</a></p>

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -8,7 +8,7 @@
 \$user = \$user ?? (\$_SESSION['user'] ?? null);
 ?>
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/views/profile/index.php
+++ b/src/views/profile/index.php
@@ -5,19 +5,21 @@ ob_start();
 ?>
 <h1>Profile</h1>
 <form method="post" action="/profile">
-    <label>Email: <input type="email" name="email" value="<?= htmlspecialchars($user['email']) ?>" required></label><br>
+    <label for="profile-email">Email:</label>
+    <input type="email" id="profile-email" name="email" value="<?= htmlspecialchars($user['email']) ?>" required><br>
     <p>Guild: <?= htmlspecialchars($user['guild']) ?></p>
     <p>Role: <?= htmlspecialchars($user['role']) ?></p>
-    <label>Display Name: <input type="text" name="display_name" value="<?= htmlspecialchars($user['display_name']) ?>" required></label><br>
-    <label>In-game Role:
-        <select name="game_role">
-            <?php $roles = ['tank'=>'Tank','dps'=>'DPS','ranged dps'=>'Ranged DPS','healer'=>'Healer']; foreach($roles as $value=> $label): ?>
-            <option value="<?= $value ?>"<?= $user['game_role']===$value?' selected':'' ?>><?= $label ?></option>
-            <?php endforeach; ?>
-        </select>
-    </label><br>
+    <label for="profile-display-name">Display Name:</label>
+    <input type="text" id="profile-display-name" name="display_name" value="<?= htmlspecialchars($user['display_name']) ?>" required><br>
+    <label for="profile-game-role">In-game Role:</label>
+    <select id="profile-game-role" name="game_role">
+        <?php $roles = ['tank'=>'Tank','dps'=>'DPS','ranged dps'=>'Ranged DPS','healer'=>'Healer']; foreach($roles as $value => $label): ?>
+        <option value="<?= $value ?>"<?= $user['game_role']===$value?' selected':'' ?>><?= $label ?></option>
+        <?php endforeach; ?>
+    </select><br>
     <button type="submit">Save</button>
 </form>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../layouts/main.php';
+?>


### PR DESCRIPTION
## Summary
- declare document language in shared layout
- label and uniquely identify all form inputs
- style focus states and buttons for better contrast and keyboard access

## Testing
- `npm test`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689dbe406018832cb90ff5ef5879e4f5