### PR TITLE
Add guild registration and membership cooldowns

### DIFF
--- a/database/guilds.sql
+++ b/database/guilds.sql
@@ -1,0 +1,19 @@
+CREATE TABLE guilds (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    leader_id BIGINT UNSIGNED NOT NULL,
+    last_leader_transfer_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    FOREIGN KEY (leader_id) REFERENCES users(id)
+);
+
+CREATE TABLE guild_members (
+    guild_id BIGINT UNSIGNED NOT NULL,
+    user_id BIGINT UNSIGNED NOT NULL,
+    joined_at DATETIME NOT NULL,
+    left_at DATETIME DEFAULT NULL,
+    PRIMARY KEY (guild_id, user_id),
+    FOREIGN KEY (guild_id) REFERENCES guilds(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -27,14 +27,10 @@ class AuthController
             echo 'Invalid CSRF token';
             return;
         }
-        $guild = trim($_POST['guild'] ?? '');
         $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
 
         $errors = [];
-        if ($guild === '') {
-            $errors['guild'] = 'Guild is required';
-        }
         if ($email === '') {
             $errors['email'] = 'Email is required';
         }
@@ -45,12 +41,12 @@ class AuthController
         if ($errors) {
             $this->showLoginForm([
                 'errors' => $errors,
-                'values' => ['guild' => $guild, 'email' => $email]
+                'values' => ['email' => $email]
             ]);
             return;
         }
 
-        $user = $this->auth->login($guild, $email, $password);
+        $user = $this->auth->login($email, $password);
         if ($user) {
             $_SESSION['user'] = $user;
             header('Location: /');
@@ -59,7 +55,7 @@ class AuthController
 
         $this->showLoginForm([
             'errors' => ['general' => 'Invalid credentials'],
-            'values' => ['guild' => $guild, 'email' => $email]
+            'values' => ['email' => $email]
         ]);
     }
 
@@ -77,7 +73,6 @@ class AuthController
             echo 'Invalid CSRF token';
             return;
         }
-        $guild = trim($_POST['guild'] ?? '');
         $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
         $display = trim($_POST['display_name'] ?? '');
@@ -85,9 +80,6 @@ class AuthController
         $gameRole = $_POST['game_role'] ?? '';
 
         $errors = [];
-        if ($guild === '') {
-            $errors['guild'] = 'Guild is required';
-        }
         if ($email === '') {
             $errors['email'] = 'Email is required';
         }
@@ -105,7 +97,6 @@ class AuthController
             $this->showRegisterForm([
                 'errors' => $errors,
                 'values' => [
-                    'guild' => $guild,
                     'email' => $email,
                     'display_name' => $display,
                     'game_role' => $gameRole
@@ -114,11 +105,10 @@ class AuthController
             return;
         }
 
-        if (!$this->auth->register($guild, $email, $password, $display, $role, $gameRole)) {
+        if (!$this->auth->register($email, $password, $display, $role, $gameRole)) {
             $this->showRegisterForm([
                 'errors' => ['email' => 'User already exists'],
                 'values' => [
-                    'guild' => $guild,
                     'email' => $email,
                     'display_name' => $display,
                     'game_role' => $gameRole

--- a/src/Controllers/ProfileController.php
+++ b/src/Controllers/ProfileController.php
@@ -26,7 +26,7 @@ class ProfileController
         $gameRole = $_POST['game_role'] ?? '';
 
         if ($email && $email !== $user['email']) {
-            $this->users->changeEmail($user['guild'], $user['email'], $email);
+            $this->users->changeEmail($user['email'], $email);
             $_SESSION['user']['email'] = $email;
             $user['email'] = $email;
         }
@@ -42,7 +42,7 @@ class ProfileController
         }
 
         if ($data) {
-            $this->users->update($user['guild'], $user['email'], $data);
+            $this->users->update($user['email'], $data);
         }
 
         $this->show();

--- a/src/Repositories/GuildRepository.php
+++ b/src/Repositories/GuildRepository.php
@@ -1,0 +1,75 @@
+<?php
+namespace App\Repositories;
+
+use App\Database;
+use PDO;
+
+class GuildRepository
+{
+    private ?PDO $db = null;
+
+    public function __construct(?PDO $db = null)
+    {
+        $this->db = $db;
+    }
+
+    private function db(): PDO
+    {
+        if ($this->db === null) {
+            $this->db = Database::connection();
+        }
+        return $this->db;
+    }
+
+    public function createGuild(string $name, int $leaderId): int
+    {
+        $stmt = $this->db()->prepare('INSERT INTO guilds (name, leader_id, last_leader_transfer_at, created_at, updated_at) VALUES (:name, :leader, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)');
+        $stmt->execute(['name' => $name, 'leader' => $leaderId]);
+        $id = (int)$this->db()->lastInsertId();
+        $this->addMember($id, $leaderId);
+        return $id;
+    }
+
+    public function getGuild(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM guilds WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $guild = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $guild ?: null;
+    }
+
+    public function addMember(int $guildId, int $userId): void
+    {
+        $stmt = $this->db()->prepare('INSERT INTO guild_members (guild_id, user_id, joined_at) VALUES (:guild, :user, CURRENT_TIMESTAMP)');
+        $stmt->execute(['guild' => $guildId, 'user' => $userId]);
+    }
+
+    public function getActiveMembership(int $userId): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM guild_members WHERE user_id = :user AND left_at IS NULL ORDER BY joined_at DESC LIMIT 1');
+        $stmt->execute(['user' => $userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public function getLastMembership(int $userId): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM guild_members WHERE user_id = :user ORDER BY joined_at DESC LIMIT 1');
+        $stmt->execute(['user' => $userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public function isMember(int $guildId, int $userId): bool
+    {
+        $stmt = $this->db()->prepare('SELECT 1 FROM guild_members WHERE guild_id = :guild AND user_id = :user AND left_at IS NULL');
+        $stmt->execute(['guild' => $guildId, 'user' => $userId]);
+        return (bool)$stmt->fetchColumn();
+    }
+
+    public function updateLeader(int $guildId, int $newLeaderId): void
+    {
+        $stmt = $this->db()->prepare('UPDATE guilds SET leader_id = :leader, last_leader_transfer_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+        $stmt->execute(['leader' => $newLeaderId, 'id' => $guildId]);
+    }
+}

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -29,7 +29,7 @@ class UserRepository
         return $this->db;
     }
 
-    public function findByEmail(string $guild, string $email): ?array
+    public function findByEmail(string $email): ?array
     {
         $stmt = $this->db()->prepare('SELECT * FROM users WHERE email = :email LIMIT 1');
         $stmt->execute(['email' => $email]);
@@ -46,7 +46,7 @@ class UserRepository
         ];
     }
 
-    public function create(string $guild, string $email, string $passwordHash, string $displayName, string $role, string $gameRole): void
+    public function create(string $email, string $passwordHash, string $displayName, string $role, string $gameRole): void
     {
         $stmt = $this->db()->prepare('INSERT INTO users (email, password_hash, display_name, role, game_role, is_active, created_at, updated_at) VALUES (:email, :password_hash, :display_name, :role, :game_role, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)');
         $stmt->execute([
@@ -58,7 +58,7 @@ class UserRepository
         ]);
     }
 
-    public function update(string $guild, string $email, array $data): void
+    public function update(string $email, array $data): void
     {
         if (empty($data)) {
             return;
@@ -75,7 +75,7 @@ class UserRepository
         $stmt->execute($data);
     }
 
-    public function changeEmail(string $guild, string $oldEmail, string $newEmail): void
+    public function changeEmail(string $oldEmail, string $newEmail): void
     {
         $stmt = $this->db()->prepare('UPDATE users SET email = :new_email, updated_at = CURRENT_TIMESTAMP WHERE email = :old_email');
         $stmt->execute([

--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -12,23 +12,23 @@ class AuthService
         $this->users = $users ?? new UserRepository();
     }
 
-    public function login(string $guild, string $email, string $password): ?array
+    public function login(string $email, string $password): ?array
     {
-        $user = $this->users->findByEmail($guild, $email);
+        $user = $this->users->findByEmail($email);
         if ($user && password_verify($password, $user['password'])) {
             unset($user['password']);
-            return $user + ['email' => $email, 'guild' => $guild];
+            return $user + ['email' => $email];
         }
         return null;
     }
 
-    public function register(string $guild, string $email, string $password, string $displayName, string $role, string $gameRole): bool
+    public function register(string $email, string $password, string $displayName, string $role, string $gameRole): bool
     {
-        if (!$guild || !$email || !$password || $this->users->findByEmail($guild, $email)) {
+        if (!$email || !$password || $this->users->findByEmail($email)) {
             return false;
         }
         $passwordHash = password_hash($password, PASSWORD_DEFAULT);
-        $this->users->create($guild, $email, $passwordHash, $displayName, $role, $gameRole);
+        $this->users->create($email, $passwordHash, $displayName, $role, $gameRole);
         return true;
     }
 }

--- a/src/Services/GuildService.php
+++ b/src/Services/GuildService.php
@@ -1,0 +1,54 @@
+<?php
+namespace App\Services;
+
+use App\Repositories\GuildRepository;
+
+class GuildService
+{
+    private GuildRepository $guilds;
+
+    public function __construct(?GuildRepository $guilds = null)
+    {
+        $this->guilds = $guilds ?? new GuildRepository();
+    }
+
+    public function registerGuild(int $leaderId, string $name): int
+    {
+        return $this->guilds->createGuild($name, $leaderId);
+    }
+
+    public function addMember(int $leaderId, int $guildId, int $userId): bool
+    {
+        $guild = $this->guilds->getGuild($guildId);
+        if (!$guild || (int)$guild['leader_id'] !== $leaderId) {
+            return false;
+        }
+        $active = $this->guilds->getActiveMembership($userId);
+        if ($active) {
+            return false;
+        }
+        $last = $this->guilds->getLastMembership($userId);
+        if ($last && strtotime($last['joined_at']) > time() - 3 * 24 * 60 * 60) {
+            return false;
+        }
+        $this->guilds->addMember($guildId, $userId);
+        return true;
+    }
+
+    public function transferLeadership(int $guildId, int $currentLeaderId, int $newLeaderId): bool
+    {
+        $guild = $this->guilds->getGuild($guildId);
+        if (!$guild || (int)$guild['leader_id'] !== $currentLeaderId) {
+            return false;
+        }
+        $last = $guild['last_leader_transfer_at'];
+        if ($last && strtotime($last) > time() - 7 * 24 * 60 * 60) {
+            return false;
+        }
+        if (!$this->guilds->isMember($guildId, $newLeaderId)) {
+            return false;
+        }
+        $this->guilds->updateLeader($guildId, $newLeaderId);
+        return true;
+    }
+}

--- a/src/views/auth/login.php
+++ b/src/views/auth/login.php
@@ -9,10 +9,6 @@ ob_start();
 <?php endif; ?>
 <form method="post" action="/login" id="loginForm" novalidate>
     <?= \App\Helpers\Csrf::inputField() ?>
-    <label for="login-guild">Guild:</label>
-    <input type="text" id="login-guild" name="guild" value="<?= htmlspecialchars($values['guild'] ?? '') ?>" required>
-    <span class="error" data-error="guild" style="color:red"><?= htmlspecialchars($errors['guild'] ?? '') ?></span><br>
-
     <label for="login-email">Email:</label>
     <input type="email" id="login-email" name="email" value="<?= htmlspecialchars($values['email'] ?? '') ?>" required>
     <span class="error" data-error="email" style="color:red"><?= htmlspecialchars($errors['email'] ?? '') ?></span><br>
@@ -27,7 +23,7 @@ ob_start();
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('loginForm');
-    const fields = ['guild', 'email', 'password'];
+    const fields = ['email', 'password'];
 
     const validateField = (field) => {
         const input = form[field];

--- a/src/views/auth/register.php
+++ b/src/views/auth/register.php
@@ -6,10 +6,6 @@ ob_start();
 <h1>Register</h1>
 <form method="post" action="/register" id="registerForm" novalidate>
     <?= \App\Helpers\Csrf::inputField() ?>
-    <label for="register-guild">Guild:</label>
-    <input type="text" id="register-guild" name="guild" value="<?= htmlspecialchars($values['guild'] ?? '') ?>" required>
-    <span class="error" data-error="guild" style="color:red"><?= htmlspecialchars($errors['guild'] ?? '') ?></span><br>
-
     <label for="register-email">Email:</label>
     <input type="email" id="register-email" name="email" value="<?= htmlspecialchars($values['email'] ?? '') ?>" required>
     <span class="error" data-error="email" style="color:red"><?= htmlspecialchars($errors['email'] ?? '') ?></span><br>
@@ -37,7 +33,7 @@ ob_start();
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('registerForm');
-    const fields = ['guild', 'email', 'password', 'display_name', 'game_role'];
+    const fields = ['email', 'password', 'display_name', 'game_role'];
 
     const validateField = (field) => {
         const input = form[field];

--- a/src/views/profile/index.php
+++ b/src/views/profile/index.php
@@ -7,7 +7,6 @@ ob_start();
 <form method="post" action="/profile">
     <label for="profile-email">Email:</label>
     <input type="email" id="profile-email" name="email" value="<?= htmlspecialchars($user['email']) ?>" required><br>
-    <p>Guild: <?= htmlspecialchars($user['guild']) ?></p>
     <p>Role: <?= htmlspecialchars($user['role']) ?></p>
     <label for="profile-display-name">Display Name:</label>
     <input type="text" id="profile-display-name" name="display_name" value="<?= htmlspecialchars($user['display_name']) ?>" required><br>

--- a/tests/Feature/AuthFeatureTest.php
+++ b/tests/Feature/AuthFeatureTest.php
@@ -35,29 +35,25 @@ class AuthFeatureTest extends TestCase
 
     public function testUserCanRegisterAndLogin(): void
     {
-        $guild = 'guild';
         $email = 'user@example.com';
         $password = 'secret';
         $display = 'User';
         $role = 'guild_member';
         $gameRole = 'mage';
 
-        $this->assertTrue($this->auth->register($guild, $email, $password, $display, $role, $gameRole));
+        $this->assertTrue($this->auth->register($email, $password, $display, $role, $gameRole));
 
-        $user = $this->auth->login($guild, $email, $password);
+        $user = $this->auth->login($email, $password);
         $this->assertSame($display, $user['display_name']);
         $this->assertSame($email, $user['email']);
-        $this->assertSame($guild, $user['guild']);
     }
 
     public function testRegistrationFailsForExistingUser(): void
     {
-        $guild = 'guild';
         $email = 'user@example.com';
         $password = 'secret';
-
-        $this->assertTrue($this->auth->register($guild, $email, $password, 'User', 'guild_member', 'mage'));
-        $this->assertFalse($this->auth->register($guild, $email, $password, 'User', 'guild_member', 'mage'));
+        $this->assertTrue($this->auth->register($email, $password, 'User', 'guild_member', 'mage'));
+        $this->assertFalse($this->auth->register($email, $password, 'User', 'guild_member', 'mage'));
     }
 }
 

--- a/tests/Unit/AuthServiceTest.php
+++ b/tests/Unit/AuthServiceTest.php
@@ -20,13 +20,12 @@ class AuthServiceTest extends TestCase
 
     public function testLoginReturnsUserOnValidCredentials(): void
     {
-        $guild = 'guild';
         $email = 'user@example.com';
         $password = 'secret';
         $hash = password_hash($password, PASSWORD_DEFAULT);
 
         $this->users->method('findByEmail')
-            ->with($guild, $email)
+            ->with($email)
             ->willReturn([
                 'password' => $hash,
                 'display_name' => 'User',
@@ -34,29 +33,27 @@ class AuthServiceTest extends TestCase
                 'game_role' => 'mage'
             ]);
 
-        $result = $this->auth->login($guild, $email, $password);
+        $result = $this->auth->login($email, $password);
 
         $this->assertSame('User', $result['display_name']);
         $this->assertSame($email, $result['email']);
-        $this->assertSame($guild, $result['guild']);
+        $this->assertArrayNotHasKey('guild', $result);
     }
 
     public function testLoginReturnsNullWithInvalidCredentials(): void
     {
-        $guild = 'guild';
         $email = 'user@example.com';
         $password = 'secret';
 
         $this->users->method('findByEmail')
-            ->with($guild, $email)
+            ->with($email)
             ->willReturn(null);
 
-        $this->assertNull($this->auth->login($guild, $email, $password));
+        $this->assertNull($this->auth->login($email, $password));
     }
 
     public function testRegisterCreatesUserWhenValid(): void
     {
-        $guild = 'guild';
         $email = 'user@example.com';
         $password = 'secret';
         $display = 'User';
@@ -65,13 +62,12 @@ class AuthServiceTest extends TestCase
 
         $this->users->expects($this->once())
             ->method('findByEmail')
-            ->with($guild, $email)
+            ->with($email)
             ->willReturn(null);
 
         $this->users->expects($this->once())
             ->method('create')
             ->with(
-                $guild,
                 $email,
                 $this->callback(fn($hash) => password_verify($password, $hash)),
                 $display,
@@ -79,12 +75,11 @@ class AuthServiceTest extends TestCase
                 $gameRole
             );
 
-        $this->assertTrue($this->auth->register($guild, $email, $password, $display, $role, $gameRole));
+        $this->assertTrue($this->auth->register($email, $password, $display, $role, $gameRole));
     }
 
     public function testRegisterFailsWhenUserExists(): void
     {
-        $guild = 'guild';
         $email = 'user@example.com';
         $password = 'secret';
         $display = 'User';
@@ -93,13 +88,13 @@ class AuthServiceTest extends TestCase
 
         $this->users->expects($this->once())
             ->method('findByEmail')
-            ->with($guild, $email)
+            ->with($email)
             ->willReturn(['password' => 'hash']);
 
         $this->users->expects($this->never())
             ->method('create');
 
-        $this->assertFalse($this->auth->register($guild, $email, $password, $display, $role, $gameRole));
+        $this->assertFalse($this->auth->register($email, $password, $display, $role, $gameRole));
     }
 }
 

--- a/tests/Unit/GuildServiceTest.php
+++ b/tests/Unit/GuildServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Repositories\GuildRepository;
+use App\Services\GuildService;
+use PHPUnit\Framework\TestCase;
+
+class GuildServiceTest extends TestCase
+{
+    public function testRegisterGuildCreatesGuild(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->expects($this->once())
+            ->method('createGuild')
+            ->with('Guild One', 1)
+            ->willReturn(10);
+
+        $this->assertSame(10, $service->registerGuild(1, 'Guild One'));
+    }
+
+    public function testAddMemberRespectsCooldown(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->method('getGuild')->with(1)->willReturn(['leader_id' => 1]);
+        $repo->method('getActiveMembership')->with(2)->willReturn(null);
+        $repo->method('getLastMembership')->with(2)->willReturn([
+            'guild_id' => 5,
+            'joined_at' => date('Y-m-d H:i:s', time() - 2 * 86400),
+            'left_at' => date('Y-m-d H:i:s', time() - 1 * 86400)
+        ]);
+        $repo->expects($this->never())->method('addMember');
+
+        $this->assertFalse($service->addMember(1, 1, 2));
+    }
+
+    public function testAddMemberSucceedsAfterCooldown(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->method('getGuild')->with(1)->willReturn(['leader_id' => 1]);
+        $repo->method('getActiveMembership')->with(2)->willReturn(null);
+        $repo->method('getLastMembership')->with(2)->willReturn([
+            'guild_id' => 5,
+            'joined_at' => date('Y-m-d H:i:s', time() - 5 * 86400),
+            'left_at' => date('Y-m-d H:i:s', time() - 4 * 86400)
+        ]);
+        $repo->expects($this->once())->method('addMember')->with(1, 2);
+
+        $this->assertTrue($service->addMember(1, 1, 2));
+    }
+
+    public function testTransferLeadershipFailsDuringCooldown(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->method('getGuild')->with(1)->willReturn([
+            'leader_id' => 1,
+            'last_leader_transfer_at' => date('Y-m-d H:i:s', time() - 3 * 86400)
+        ]);
+        $repo->method('isMember')->with(1, 2)->willReturn(true);
+        $repo->expects($this->never())->method('updateLeader');
+
+        $this->assertFalse($service->transferLeadership(1, 1, 2));
+    }
+
+    public function testTransferLeadershipSucceedsAfterCooldown(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->method('getGuild')->with(1)->willReturn([
+            'leader_id' => 1,
+            'last_leader_transfer_at' => date('Y-m-d H:i:s', time() - 8 * 86400)
+        ]);
+        $repo->method('isMember')->with(1, 2)->willReturn(true);
+        $repo->expects($this->once())->method('updateLeader')->with(1, 2);
+
+        $this->assertTrue($service->transferLeadership(1, 1, 2));
+    }
+}


### PR DESCRIPTION
## Summary
- remove guild field from user registration to rely solely on email and password
- introduce guild repository and service to register guilds, add members with a 3-day cooldown, and transfer leadership with a 1-week cooldown
- provide SQL schema for guilds and memberships and unit tests for guild logic

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689ed23173d0832ca42432b6987d6353