### PR TITLE
Handle database failures during login

### DIFF
--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -14,11 +14,18 @@ class AuthService
 
     public function login(string $email, string $password): ?array
     {
-        $user = $this->users->findByEmail($email);
+        try {
+            $user = $this->users->findByEmail($email);
+        } catch (\PDOException $e) {
+            // Gracefully handle database errors during login
+            return null;
+        }
+
         if ($user && password_verify($password, $user['password'])) {
             unset($user['password']);
             return $user + ['email' => $email];
         }
+
         return null;
     }
 

--- a/tests/Unit/AuthServiceTest.php
+++ b/tests/Unit/AuthServiceTest.php
@@ -52,6 +52,18 @@ class AuthServiceTest extends TestCase
         $this->assertNull($this->auth->login($email, $password));
     }
 
+    public function testLoginHandlesDatabaseExceptionsGracefully(): void
+    {
+        $email = 'user@example.com';
+        $password = 'secret';
+
+        $this->users->method('findByEmail')
+            ->with($email)
+            ->willThrowException(new \PDOException('DB error'));
+
+        $this->assertNull($this->auth->login($email, $password));
+    }
+
     public function testRegisterCreatesUserWhenValid(): void
     {
         $email = 'user@example.com';


### PR DESCRIPTION
## Summary
- Avoid fatal error when the database is unreachable during login
- Test login gracefully handles repository exceptions

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689f42acd6d0832c98d6e68a73f3cf21