### PR TITLE
Add admin guild management features

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -8,12 +8,14 @@ use App\Controllers\ProfileController;
 use App\Controllers\AuctionController;
 use App\Controllers\EventController;
 use App\Controllers\ManagementController;
+use App\Controllers\GuildController;
 
 $auth = new AuthController();
 $profile = new ProfileController();
 $auction = new AuctionController();
 $event = new EventController();
 $management = new ManagementController();
+$guild = new GuildController();
 
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 $method = $_SERVER['REQUEST_METHOD'];

--- a/src/Controllers/GuildController.php
+++ b/src/Controllers/GuildController.php
@@ -1,0 +1,58 @@
+<?php
+namespace App\Controllers;
+
+use App\Helpers\Csrf;
+use App\Services\GuildService;
+
+class GuildController
+{
+    private GuildService $guilds;
+
+    public function __construct()
+    {
+        $this->guilds = new GuildService();
+    }
+
+    public function showRegisterForm(array $data = []): void
+    {
+        $errors = $data['errors'] ?? [];
+        $values = $data['values'] ?? [];
+        include __DIR__ . '/../views/guild/register.php';
+    }
+
+    public function index(): void
+    {
+        $guilds = $this->guilds->listGuilds();
+        include __DIR__ . '/../views/guild/index.php';
+    }
+
+    public function register(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            echo 'Invalid CSRF token';
+            return;
+        }
+        $name = trim($_POST['name'] ?? '');
+        $leaderId = (int)($_SESSION['user']['id'] ?? 0);
+        $errors = [];
+        if ($name === '') {
+            $errors['name'] = 'Name is required';
+        }
+        if ($leaderId === 0) {
+            http_response_code(403);
+            echo 'Unauthorized';
+            return;
+        }
+        if ($errors) {
+            $this->showRegisterForm([
+                'errors' => $errors,
+                'values' => ['name' => $name]
+            ]);
+            return;
+        }
+        $this->guilds->registerGuild($leaderId, $name);
+        header('Location: /');
+        exit;
+    }
+}

--- a/src/Repositories/GuildRepository.php
+++ b/src/Repositories/GuildRepository.php
@@ -72,4 +72,44 @@ class GuildRepository
         $stmt = $this->db()->prepare('UPDATE guilds SET leader_id = :leader, last_leader_transfer_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
         $stmt->execute(['leader' => $newLeaderId, 'id' => $guildId]);
     }
+
+    /**
+     * Fetch all guilds. Used by administrators to review guild listings.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getAllGuilds(): array
+    {
+        $stmt = $this->db()->query('SELECT * FROM guilds');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Mark a guild as blocked. The schema is expected to contain a `blocked`
+     * column. This repository does not enforce the schema but issues the SQL
+     * update so higher layers can flag a guild as suspended.
+     */
+    public function blockGuild(int $guildId): void
+    {
+        $stmt = $this->db()->prepare('UPDATE guilds SET blocked = 1, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+        $stmt->execute(['id' => $guildId]);
+    }
+
+    /**
+     * Ban a guild permanently.
+     */
+    public function banGuild(int $guildId): void
+    {
+        $stmt = $this->db()->prepare('UPDATE guilds SET banned = 1, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+        $stmt->execute(['id' => $guildId]);
+    }
+
+    /**
+     * Remove a guild entirely.
+     */
+    public function deleteGuild(int $guildId): void
+    {
+        $stmt = $this->db()->prepare('DELETE FROM guilds WHERE id = :id');
+        $stmt->execute(['id' => $guildId]);
+    }
 }

--- a/src/Services/GuildService.php
+++ b/src/Services/GuildService.php
@@ -51,4 +51,61 @@ class GuildService
         $this->guilds->updateLeader($guildId, $newLeaderId);
         return true;
     }
+
+    /**
+     * Return all guilds for administrative review.
+     */
+    public function listGuilds(): array
+    {
+        return $this->guilds->getAllGuilds();
+    }
+
+    /**
+     * Allow an administrator to join a guild either as a regular member or as
+     * the leader. This bypasses the normal leader and cooldown checks.
+     */
+    public function adminJoinGuild(int $guildId, int $userId, bool $asLeader = false): bool
+    {
+        $active = $this->guilds->getActiveMembership($userId);
+        if ($active) {
+            return false;
+        }
+        $this->guilds->addMember($guildId, $userId);
+        if ($asLeader) {
+            $this->guilds->updateLeader($guildId, $userId);
+        }
+        return true;
+    }
+
+    /**
+     * Block a guild from performing operations.
+     */
+    public function blockGuild(int $guildId): void
+    {
+        $this->guilds->blockGuild($guildId);
+    }
+
+    /**
+     * Ban a guild.
+     */
+    public function banGuild(int $guildId): void
+    {
+        $this->guilds->banGuild($guildId);
+    }
+
+    /**
+     * Remove a guild entirely.
+     */
+    public function removeGuild(int $guildId): void
+    {
+        $this->guilds->deleteGuild($guildId);
+    }
+
+    /**
+     * Change the leader of a guild immediately.
+     */
+    public function changeLeader(int $guildId, int $newLeaderId): void
+    {
+        $this->guilds->updateLeader($guildId, $newLeaderId);
+    }
 }

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -21,6 +21,27 @@ return [
     '/logout' => [
         'GET' => [$auth, 'logout'],
     ],
+    '/guild/register' => [
+        'GET' => function () use ($requireLogin, $guild) {
+            $requireLogin();
+            $guild->showRegisterForm();
+        },
+        'POST' => function () use ($requireLogin, $guild) {
+            $requireLogin();
+            $guild->register();
+        },
+    ],
+    '/guilds' => [
+        'GET' => function () use ($requireLogin, $guild, $user) {
+            $requireLogin();
+            if ($user['role'] !== 'admin') {
+                http_response_code(403);
+                echo 'Forbidden';
+            } else {
+                $guild->index();
+            }
+        },
+    ],
     '/auctions' => [
         'GET' => function () use ($requireLogin, $auction) {
             $requireLogin();

--- a/src/views/guild/index.php
+++ b/src/views/guild/index.php
@@ -1,0 +1,19 @@
+<?php
+$title = 'Guilds';
+$currentPage = 'guilds';
+ob_start();
+?>
+<h1>Guilds</h1>
+<table>
+    <tr><th>ID</th><th>Name</th><th>Leader</th></tr>
+    <?php foreach ($guilds as $g): ?>
+        <tr>
+            <td><?= htmlspecialchars($g['id']) ?></td>
+            <td><?= htmlspecialchars($g['name']) ?></td>
+            <td><?= htmlspecialchars($g['leader_id']) ?></td>
+        </tr>
+    <?php endforeach; ?>
+</table>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/guild/register.php
+++ b/src/views/guild/register.php
@@ -1,0 +1,16 @@
+<?php
+$title = 'Register Guild';
+$currentPage = 'guild_register';
+ob_start();
+?>
+<h1>Register Guild</h1>
+<form method="post" action="/guild/register" id="guildRegisterForm" novalidate>
+    <?= \App\Helpers\Csrf::inputField() ?>
+    <label for="guild-name">Guild Name:</label>
+    <input type="text" id="guild-name" name="name" value="<?= htmlspecialchars($values['name'] ?? '') ?>" required>
+    <span class="error" data-error="name" style="color:red"><?= htmlspecialchars($errors['name'] ?? '') ?></span><br>
+    <button type="submit">Create Guild</button>
+</form>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -37,6 +37,10 @@ $user = $user ?? ($_SESSION['user'] ?? null);
                     <?php if ($user['role'] !== 'guild_member'): ?>
                         <li class="nav-item"><a class="nav-link <?= $currentPage === 'management' ? 'active' : '' ?>" href="/management">Management</a></li>
                     <?php endif; ?>
+                    <li class="nav-item"><a class="nav-link <?= $currentPage === 'guild_register' ? 'active' : '' ?>" href="/guild/register">New Guild</a></li>
+                    <?php if ($user['role'] === 'admin'): ?>
+                        <li class="nav-item"><a class="nav-link <?= $currentPage === 'guilds' ? 'active' : '' ?>" href="/guilds">Guilds</a></li>
+                    <?php endif; ?>
                     <li class="nav-item"><a class="nav-link" href="/logout">Logout</a></li>
                 <?php else: ?>
                     <li class="nav-item"><a class="nav-link <?= $currentPage === 'login' ? 'active' : '' ?>" href="/login">Login</a></li>

--- a/tests/Unit/AdminGuildServiceTest.php
+++ b/tests/Unit/AdminGuildServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Tests\Unit;
+
+use App\Repositories\GuildRepository;
+use App\Services\GuildService;
+use PHPUnit\Framework\TestCase;
+
+class AdminGuildServiceTest extends TestCase
+{
+    public function testListGuildsReturnsRepositoryData(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+        $repo->expects($this->once())->method('getAllGuilds')->willReturn([
+            ['id' => 1, 'name' => 'Guild A']
+        ]);
+        $this->assertSame([
+            ['id' => 1, 'name' => 'Guild A']
+        ], $service->listGuilds());
+    }
+
+    public function testAdminJoinGuildAsLeaderUpdatesLeader(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+        $repo->method('getActiveMembership')->with(5)->willReturn(null);
+        $repo->expects($this->once())->method('addMember')->with(3, 5);
+        $repo->expects($this->once())->method('updateLeader')->with(3, 5);
+        $this->assertTrue($service->adminJoinGuild(3, 5, true));
+    }
+
+    public function testBlockGuildCallsRepository(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+        $repo->expects($this->once())->method('blockGuild')->with(7);
+        $service->blockGuild(7);
+    }
+}


### PR DESCRIPTION
## Summary
- allow administrators to join guilds, list them, and block, ban, remove, or change leaders
- add GuildController with registration form and guild list views
- expose new `/guild/register` and `/guilds` routes and navigation links

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a5c40c2730832cace9f62cc4763ce1