### PR TITLE
Include user ID in session for guild creation

### DIFF
--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -38,6 +38,7 @@ class UserRepository
             return null;
         }
         return [
+            'id' => $user['id'],
             'password' => $user['password_hash'],
             'display_name' => $user['display_name'],
             'role' => $user['role'],

--- a/tests/Unit/AuthServiceTest.php
+++ b/tests/Unit/AuthServiceTest.php
@@ -27,6 +27,7 @@ class AuthServiceTest extends TestCase
         $this->users->method('findByEmail')
             ->with($email)
             ->willReturn([
+                'id' => 1,
                 'password' => $hash,
                 'display_name' => 'User',
                 'role' => 'admin',
@@ -37,6 +38,7 @@ class AuthServiceTest extends TestCase
 
         $this->assertSame('User', $result['display_name']);
         $this->assertSame($email, $result['email']);
+        $this->assertSame(1, $result['id']);
         $this->assertArrayNotHasKey('guild', $result);
     }
 


### PR DESCRIPTION
## Summary
- Ensure `findByEmail` returns user ID so logged-in sessions include it
- Update auth service test to cover returned user ID

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a5c8a60bf4832cb5824682045d3495