### PR TITLE
Manage guild membership and default user roles

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -105,7 +105,7 @@ class AuthController
             return;
         }
 
-        if (!$this->auth->register($email, $password, $display, $role, $gameRole)) {
+        if (!$this->auth->register($email, $password, $display, $gameRole, $role)) {
             $this->showRegisterForm([
                 'errors' => ['email' => 'User already exists'],
                 'values' => [

--- a/src/Controllers/GuildController.php
+++ b/src/Controllers/GuildController.php
@@ -52,6 +52,9 @@ class GuildController
             return;
         }
         $this->guilds->registerGuild($leaderId, $name);
+        $users = new \App\Repositories\UserRepository();
+        $users->update($_SESSION['user']['email'], ['role' => 'guild_leader']);
+        $_SESSION['user']['role'] = 'guild_leader';
         header('Location: /');
         exit;
     }

--- a/src/Controllers/ProfileController.php
+++ b/src/Controllers/ProfileController.php
@@ -2,19 +2,28 @@
 namespace App\Controllers;
 
 use App\Repositories\UserRepository;
+use App\Services\GuildService;
 
 class ProfileController
 {
     private UserRepository $users;
+    private GuildService $guilds;
 
     public function __construct()
     {
         $this->users = new UserRepository();
+        $this->guilds = new GuildService();
     }
 
     public function show(): void
     {
         $user = $_SESSION['user'];
+        $guilds = $this->guilds->listGuilds();
+        $membership = $this->guilds->getActiveMembership($user['id']);
+        $currentGuild = null;
+        if ($membership) {
+            $currentGuild = $this->guilds->getGuild((int)$membership['guild_id']);
+        }
         include __DIR__ . '/../views/profile/index.php';
     }
 
@@ -46,5 +55,27 @@ class ProfileController
         }
 
         $this->show();
+    }
+
+    public function joinGuild(): void
+    {
+        $user = $_SESSION['user'];
+        $guildId = (int)($_POST['guild_id'] ?? 0);
+        if ($guildId) {
+            $this->guilds->joinGuild($user['id'], $guildId);
+            $_SESSION['user']['role'] = 'guild_member';
+        }
+        header('Location: /profile');
+        exit;
+    }
+
+    public function leaveGuild(): void
+    {
+        $user = $_SESSION['user'];
+        $this->guilds->leaveGuild($user['id']);
+        $this->users->update($user['email'], ['role' => 'guild_member']);
+        $_SESSION['user']['role'] = 'guild_member';
+        header('Location: /profile');
+        exit;
     }
 }

--- a/src/Repositories/GuildRepository.php
+++ b/src/Repositories/GuildRepository.php
@@ -44,6 +44,12 @@ class GuildRepository
         $stmt->execute(['guild' => $guildId, 'user' => $userId]);
     }
 
+    public function leaveGuild(int $userId): void
+    {
+        $stmt = $this->db()->prepare('UPDATE guild_members SET left_at = CURRENT_TIMESTAMP WHERE user_id = :user AND left_at IS NULL');
+        $stmt->execute(['user' => $userId]);
+    }
+
     public function getActiveMembership(int $userId): ?array
     {
         $stmt = $this->db()->prepare('SELECT * FROM guild_members WHERE user_id = :user AND left_at IS NULL ORDER BY joined_at DESC LIMIT 1');

--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -29,7 +29,7 @@ class AuthService
         return null;
     }
 
-    public function register(string $email, string $password, string $displayName, string $role, string $gameRole): bool
+    public function register(string $email, string $password, string $displayName, string $gameRole, string $role = 'guild_member'): bool
     {
         if (!$email || !$password || $this->users->findByEmail($email)) {
             return false;

--- a/src/Services/GuildService.php
+++ b/src/Services/GuildService.php
@@ -14,6 +14,10 @@ class GuildService
 
     public function registerGuild(int $leaderId, string $name): int
     {
+        $active = $this->guilds->getActiveMembership($leaderId);
+        if ($active) {
+            $this->guilds->leaveGuild($leaderId);
+        }
         return $this->guilds->createGuild($name, $leaderId);
     }
 
@@ -33,6 +37,31 @@ class GuildService
         }
         $this->guilds->addMember($guildId, $userId);
         return true;
+    }
+
+    public function leaveGuild(int $userId): void
+    {
+        $this->guilds->leaveGuild($userId);
+    }
+
+    public function joinGuild(int $userId, int $guildId): bool
+    {
+        $active = $this->guilds->getActiveMembership($userId);
+        if ($active) {
+            $this->guilds->leaveGuild($userId);
+        }
+        $this->guilds->addMember($guildId, $userId);
+        return true;
+    }
+
+    public function getActiveMembership(int $userId): ?array
+    {
+        return $this->guilds->getActiveMembership($userId);
+    }
+
+    public function getGuild(int $id): ?array
+    {
+        return $this->guilds->getGuild($id);
     }
 
     public function transferLeadership(int $guildId, int $currentLeaderId, int $newLeaderId): bool

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -70,6 +70,18 @@ return [
             $profile->update();
         },
     ],
+    '/profile/join' => [
+        'POST' => function () use ($requireLogin, $profile) {
+            $requireLogin();
+            $profile->joinGuild();
+        },
+    ],
+    '/profile/leave' => [
+        'POST' => function () use ($requireLogin, $profile) {
+            $requireLogin();
+            $profile->leaveGuild();
+        },
+    ],
     '/management' => [
         'GET' => function () use ($requireLogin, $user, $management) {
             $requireLogin();

--- a/src/views/profile/index.php
+++ b/src/views/profile/index.php
@@ -18,6 +18,30 @@ ob_start();
     </select><br>
     <button type="submit">Save</button>
 </form>
+
+<h2>Guilds</h2>
+<?php if ($currentGuild): ?>
+    <p>Current Guild: <?= htmlspecialchars($currentGuild['name']) ?></p>
+    <form method="post" action="/profile/leave" style="display:inline">
+        <button type="submit">Leave Guild</button>
+    </form>
+<?php else: ?>
+    <p>Not currently in a guild.</p>
+<?php endif; ?>
+
+<ul>
+<?php foreach ($guilds as $g): ?>
+    <li>
+        <?= htmlspecialchars($g['name']) ?>
+        <?php if (!$currentGuild || $currentGuild['id'] !== $g['id']): ?>
+            <form method="post" action="/profile/join" style="display:inline">
+                <input type="hidden" name="guild_id" value="<?= $g['id'] ?>">
+                <button type="submit">Join</button>
+            </form>
+        <?php endif; ?>
+    </li>
+<?php endforeach; ?>
+</ul>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../layouts/main.php';

--- a/tests/Feature/AuthFeatureTest.php
+++ b/tests/Feature/AuthFeatureTest.php
@@ -41,7 +41,7 @@ class AuthFeatureTest extends TestCase
         $role = 'guild_member';
         $gameRole = 'mage';
 
-        $this->assertTrue($this->auth->register($email, $password, $display, $role, $gameRole));
+        $this->assertTrue($this->auth->register($email, $password, $display, $gameRole, $role));
 
         $user = $this->auth->login($email, $password);
         $this->assertSame($display, $user['display_name']);
@@ -52,8 +52,8 @@ class AuthFeatureTest extends TestCase
     {
         $email = 'user@example.com';
         $password = 'secret';
-        $this->assertTrue($this->auth->register($email, $password, 'User', 'guild_member', 'mage'));
-        $this->assertFalse($this->auth->register($email, $password, 'User', 'guild_member', 'mage'));
+        $this->assertTrue($this->auth->register($email, $password, 'User', 'mage', 'guild_member'));
+        $this->assertFalse($this->auth->register($email, $password, 'User', 'mage', 'guild_member'));
     }
 }
 

--- a/tests/Unit/AuthServiceTest.php
+++ b/tests/Unit/AuthServiceTest.php
@@ -87,7 +87,32 @@ class AuthServiceTest extends TestCase
                 $gameRole
             );
 
-        $this->assertTrue($this->auth->register($email, $password, $display, $role, $gameRole));
+        $this->assertTrue($this->auth->register($email, $password, $display, $gameRole, $role));
+    }
+
+    public function testRegisterDefaultsToMemberRole(): void
+    {
+        $email = 'new@example.com';
+        $password = 'secret';
+        $display = 'New';
+        $gameRole = 'mage';
+
+        $this->users->expects($this->once())
+            ->method('findByEmail')
+            ->with($email)
+            ->willReturn(null);
+
+        $this->users->expects($this->once())
+            ->method('create')
+            ->with(
+                $email,
+                $this->callback(fn($hash) => password_verify($password, $hash)),
+                $display,
+                'guild_member',
+                $gameRole
+            );
+
+        $this->assertTrue($this->auth->register($email, $password, $display, $gameRole));
     }
 
     public function testRegisterFailsWhenUserExists(): void
@@ -106,7 +131,7 @@ class AuthServiceTest extends TestCase
         $this->users->expects($this->never())
             ->method('create');
 
-        $this->assertFalse($this->auth->register($email, $password, $display, $role, $gameRole));
+        $this->assertFalse($this->auth->register($email, $password, $display, $gameRole, $role));
     }
 }
 

--- a/tests/Unit/GuildServiceTest.php
+++ b/tests/Unit/GuildServiceTest.php
@@ -13,12 +13,38 @@ class GuildServiceTest extends TestCase
         $repo = $this->createMock(GuildRepository::class);
         $service = new GuildService($repo);
 
+        $repo->expects($this->once())->method('getActiveMembership')->with(1)->willReturn(null);
+        $repo->expects($this->never())->method('leaveGuild');
         $repo->expects($this->once())
             ->method('createGuild')
             ->with('Guild One', 1)
             ->willReturn(10);
 
         $this->assertSame(10, $service->registerGuild(1, 'Guild One'));
+    }
+
+    public function testRegisterGuildLeavesExistingGuild(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->expects($this->once())->method('getActiveMembership')->with(1)->willReturn(['guild_id' => 2]);
+        $repo->expects($this->once())->method('leaveGuild')->with(1);
+        $repo->expects($this->once())->method('createGuild')->with('Guild Two', 1)->willReturn(11);
+
+        $this->assertSame(11, $service->registerGuild(1, 'Guild Two'));
+    }
+
+    public function testJoinGuildLeavesExistingGuild(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->method('getActiveMembership')->with(5)->willReturn(['guild_id' => 2]);
+        $repo->expects($this->once())->method('leaveGuild')->with(5);
+        $repo->expects($this->once())->method('addMember')->with(3, 5);
+
+        $this->assertTrue($service->joinGuild(5, 3));
     }
 
     public function testAddMemberRespectsCooldown(): void


### PR DESCRIPTION
## Summary
- Default new registrations to `guild_member` and simplify registration API
- Ensure guild creation transfers leader and updates user role
- Add profile-based guild management including join and leave actions

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c96fc2fc832c96a88d36c2186b6d