### PR TITLE
Show PHP errors as in-page alerts

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -35,5 +35,6 @@ if (isset($routes[$uri][$method])) {
     $action();
 } else {
     http_response_code(404);
-    echo 'Not Found';
+    $message = 'Not Found';
+    include __DIR__ . '/../src/views/errors/error.php';
 }

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -22,12 +22,13 @@ class AuthController
 
     public function login(): void
     {
+        $email = trim($_POST['email'] ?? '');
         if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
             http_response_code(400);
-            echo 'Invalid CSRF token';
+            $_SESSION['error'] = 'Invalid CSRF token';
+            $this->showLoginForm(['values' => ['email' => $email]]);
             return;
         }
-        $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
 
         $errors = [];
@@ -53,8 +54,8 @@ class AuthController
             exit;
         }
 
+        $_SESSION['error'] = 'Invalid credentials';
         $this->showLoginForm([
-            'errors' => ['general' => 'Invalid credentials'],
             'values' => ['email' => $email]
         ]);
     }
@@ -68,16 +69,23 @@ class AuthController
 
     public function register(): void
     {
-        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
-            http_response_code(400);
-            echo 'Invalid CSRF token';
-            return;
-        }
         $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
         $display = trim($_POST['display_name'] ?? '');
         $role = 'guild_member'; // Elevated roles must be granted by an administrator
         $gameRole = $_POST['game_role'] ?? '';
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            $this->showRegisterForm([
+                'values' => [
+                    'email' => $email,
+                    'display_name' => $display,
+                    'game_role' => $gameRole
+                ]
+            ]);
+            return;
+        }
 
         $errors = [];
         if ($email === '') {
@@ -117,7 +125,9 @@ class AuthController
             return;
         }
 
-        echo 'Registration successful. <a href="/login">Login</a>';
+        $_SESSION['success'] = 'Registration successful. Please login.';
+        header('Location: /login');
+        exit;
     }
 
     public function logout(): void
@@ -137,7 +147,8 @@ class AuthController
     {
         if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
             http_response_code(400);
-            echo 'Invalid CSRF token';
+            $_SESSION['error'] = 'Invalid CSRF token';
+            $this->showForgotForm();
             return;
         }
         $email = $_POST['email'] ?? '';

--- a/src/Controllers/GuildController.php
+++ b/src/Controllers/GuildController.php
@@ -30,7 +30,8 @@ class GuildController
     {
         if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
             http_response_code(400);
-            echo 'Invalid CSRF token';
+            $_SESSION['error'] = 'Invalid CSRF token';
+            $this->showRegisterForm();
             return;
         }
         $name = trim($_POST['name'] ?? '');
@@ -41,7 +42,10 @@ class GuildController
         }
         if ($leaderId === 0) {
             http_response_code(403);
-            echo 'Unauthorized';
+            $_SESSION['error'] = 'Unauthorized';
+            $this->showRegisterForm([
+                'values' => ['name' => $name]
+            ]);
             return;
         }
         if ($errors) {

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -36,7 +36,8 @@ return [
             $requireLogin();
             if ($user['role'] !== 'admin') {
                 http_response_code(403);
-                echo 'Forbidden';
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
             } else {
                 $guild->index();
             }
@@ -75,7 +76,8 @@ return [
             $requireLogin();
             if ($user['role'] === 'guild_member') {
                 http_response_code(403);
-                echo 'Forbidden';
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
             } else {
                 $management->index();
             }

--- a/src/views/auth/login.php
+++ b/src/views/auth/login.php
@@ -4,9 +4,6 @@ $currentPage = 'login';
 ob_start();
 ?>
 <h1>Login</h1>
-<?php if (!empty($errors['general'])): ?>
-<p style="color:red"><?= htmlspecialchars($errors['general']) ?></p>
-<?php endif; ?>
 <form method="post" action="/login" id="loginForm" novalidate>
     <?= \App\Helpers\Csrf::inputField() ?>
     <label for="login-email">Email:</label>

--- a/src/views/errors/error.php
+++ b/src/views/errors/error.php
@@ -1,0 +1,11 @@
+<?php
+$title = 'Error';
+ob_start();
+?>
+<div class="alert alert-danger" role="alert">
+    <?= htmlspecialchars($message ?? 'An error occurred.') ?>
+</div>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../layouts/main.php';
+

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -51,6 +51,18 @@ $user = $user ?? ($_SESSION['user'] ?? null);
     </div>
 </nav>
 <main class="site-main container">
+    <?php if (!empty($_SESSION['success'])): ?>
+        <div class="alert alert-success" role="alert">
+            <?= htmlspecialchars($_SESSION['success']) ?>
+        </div>
+        <?php unset($_SESSION['success']); ?>
+    <?php endif; ?>
+    <?php if (!empty($_SESSION['error'])): ?>
+        <div class="alert alert-danger" role="alert">
+            <?= htmlspecialchars($_SESSION['error']) ?>
+        </div>
+        <?php unset($_SESSION['error']); ?>
+    <?php endif; ?>
     <?= $content ?? '' ?>
 </main>
 <footer class="site-footer">


### PR DESCRIPTION
## Summary
- Display session-based success and error messages as Bootstrap alerts on every page
- Replace raw echo error outputs in controllers with session alerts and form re-renders
- Serve generic error view for forbidden/404 routes instead of blank messages

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c9ec8eb8832c802f799ebf226704