### PR TITLE
Restrict management tab to privileged roles

### DIFF
--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -85,7 +85,7 @@ return [
     '/management' => [
         'GET' => function () use ($requireLogin, $user, $management) {
             $requireLogin();
-            if ($user['role'] === 'guild_member') {
+            if (!in_array($user['role'], ['admin', 'guild_leader', 'guild_advisor'])) {
                 http_response_code(403);
                 echo 'Forbidden';
             } else {

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -34,7 +34,7 @@ $user = $user ?? ($_SESSION['user'] ?? null);
                 <li class="nav-item"><a class="nav-link <?= $currentPage === 'event-history' ? 'active' : '' ?>" href="/event-history">Event History</a></li>
                 <?php if ($user): ?>
                     <li class="nav-item"><a class="nav-link <?= $currentPage === 'profile' ? 'active' : '' ?>" href="/profile">Profile</a></li>
-                    <?php if ($user['role'] !== 'guild_member'): ?>
+                    <?php if (in_array($user['role'], ['admin', 'guild_leader', 'guild_advisor'])): ?>
                         <li class="nav-item"><a class="nav-link <?= $currentPage === 'management' ? 'active' : '' ?>" href="/management">Management</a></li>
                     <?php endif; ?>
                     <li class="nav-item"><a class="nav-link <?= $currentPage === 'guild_register' ? 'active' : '' ?>" href="/guild/register">New Guild</a></li>


### PR DESCRIPTION
## Summary
- Show management navigation only to admin, guild leader, and guild advisor roles
- Guard /management route so guild members are denied access

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5cc8b8f10832c82ef3cb3dad7e6b9