### PR TITLE
feat: add guild message of the day

### DIFF
--- a/src/Controllers/ManagementController.php
+++ b/src/Controllers/ManagementController.php
@@ -3,20 +3,31 @@ namespace App\Controllers;
 
 use App\Repositories\AuctionRepository;
 use App\Repositories\EventRepository;
+use App\Helpers\Csrf;
+use App\Services\GuildService;
 
 class ManagementController
 {
     private AuctionRepository $auctions;
     private EventRepository $events;
+    private GuildService $guilds;
 
     public function __construct()
     {
         $this->auctions = new AuctionRepository();
         $this->events = new EventRepository();
+        $this->guilds = new GuildService();
     }
 
     public function index(): void
     {
+        $user = $_SESSION['user'];
+        $membership = $this->guilds->getActiveMembership($user['id']);
+        $currentGuild = null;
+        if ($membership) {
+            $currentGuild = $this->guilds->getGuild((int)$membership['guild_id']);
+        }
+
         // Auctions
         $auctionPage = max(1, (int)($_GET['auction_page'] ?? 1));
         $auctionSort = $_GET['auction_sort'] ?? 'id';
@@ -47,5 +58,34 @@ class ManagementController
         $eventItems = array_slice($eventItems, ($eventPage - 1) * $perPage, $perPage);
 
         include __DIR__ . '/../views/management/index.php';
+    }
+
+    public function updateMotd(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $user = $_SESSION['user'];
+        $motd = trim($_POST['motd'] ?? '');
+        $membership = $this->guilds->getActiveMembership($user['id']);
+        if (!$membership) {
+            $_SESSION['error'] = 'You are not part of a guild';
+            header('Location: /management');
+            exit;
+        }
+        $guild = $this->guilds->getGuild((int)$membership['guild_id']);
+        if ($user['role'] !== 'admin' && (int)$guild['leader_id'] !== (int)$user['id']) {
+            http_response_code(403);
+            $_SESSION['error'] = 'Forbidden';
+            header('Location: /management');
+            exit;
+        }
+        $this->guilds->setMotd((int)$membership['guild_id'], $motd);
+        $_SESSION['success'] = 'Message of the day updated';
+        header('Location: /management');
+        exit;
     }
 }

--- a/src/Repositories/GuildRepository.php
+++ b/src/Repositories/GuildRepository.php
@@ -80,6 +80,15 @@ class GuildRepository
     }
 
     /**
+     * Update the message of the day for the given guild.
+     */
+    public function updateMotd(int $guildId, string $motd): void
+    {
+        $stmt = $this->db()->prepare('UPDATE guilds SET motd = :motd, updated_at = CURRENT_TIMESTAMP WHERE id = :id');
+        $stmt->execute(['motd' => $motd, 'id' => $guildId]);
+    }
+
+    /**
      * Fetch all guilds. Used by administrators to review guild listings.
      *
      * @return array<int, array<string, mixed>>

--- a/src/Services/GuildService.php
+++ b/src/Services/GuildService.php
@@ -64,6 +64,11 @@ class GuildService
         return $this->guilds->getGuild($id);
     }
 
+    public function setMotd(int $guildId, string $motd): void
+    {
+        $this->guilds->updateMotd($guildId, $motd);
+    }
+
     public function transferLeadership(int $guildId, int $currentLeaderId, int $newLeaderId): bool
     {
         $guild = $this->guilds->getGuild($guildId);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -95,4 +95,16 @@ return [
             }
         },
     ],
+    '/management/motd' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if ($user['role'] === 'guild_member') {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->updateMotd();
+            }
+        },
+    ],
 ];

--- a/src/views/home.php
+++ b/src/views/home.php
@@ -2,10 +2,22 @@
 $u = $_SESSION['user'] ?? null;
 $title = 'DKP Home';
 $currentPage = 'home';
+$motd = null;
+if ($u) {
+    $guildService = new \App\Services\GuildService();
+    $membership = $guildService->getActiveMembership($u['id']);
+    if ($membership) {
+        $guild = $guildService->getGuild((int)$membership['guild_id']);
+        $motd = $guild['motd'] ?? null;
+    }
+}
 ob_start();
 ?>
 <?php if (!empty($u)): ?>
     <h1>Welcome, <?= htmlspecialchars($u['display_name']) ?></h1>
+    <?php if (!empty($motd)): ?>
+        <p class="motd"><?= htmlspecialchars($motd) ?></p>
+    <?php endif; ?>
     <p>This site tracks guild activity points and loot auctions.</p>
     <p>Use the navigation links above to manage your guild.</p>
 <?php else: ?>

--- a/src/views/management/index.php
+++ b/src/views/management/index.php
@@ -5,6 +5,15 @@ ob_start();
 ?>
 <h1>Management</h1>
 
+<?php if (!empty($currentGuild)): ?>
+<h2>Message of the Day</h2>
+<form method="post" action="/management/motd" id="motdForm">
+    <?= \App\Helpers\Csrf::inputField() ?>
+    <textarea name="motd" id="motd" rows="3" cols="50"><?= htmlspecialchars($currentGuild['motd'] ?? '') ?></textarea><br>
+    <button type="submit">Save</button>
+</form>
+<?php endif; ?>
+
 <h2>Auctions</h2>
 <table>
     <thead>

--- a/tests/Unit/GuildServiceTest.php
+++ b/tests/Unit/GuildServiceTest.php
@@ -110,4 +110,14 @@ class GuildServiceTest extends TestCase
 
         $this->assertTrue($service->transferLeadership(1, 1, 2));
     }
+
+    public function testSetMotdUpdatesRepository(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->expects($this->once())->method('updateMotd')->with(3, 'Be brave');
+
+        $service->setMotd(3, 'Be brave');
+    }
 }


### PR DESCRIPTION
## Summary
- allow guild leaders to set a message of the day from the management panel
- show guild message of the day on the home page for members
- cover new service method with unit tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a5caf0f4f4832cb9388bb12c606ea1