### PR TITLE
Align role and game role enums with database schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ namespaced classes from `src/`.
 
 ## Roles
 
-All users register as `guild_member`. Elevated roles such as `guild_advisor`, `guild_leader`, or `admin` must be granted by an administrator after registration. A privileged user can promote members by updating their role through the management tooling or by calling `UserRepository::update` in custom workflows.
+All users register as `MEMBER`. Elevated roles such as `ADVISOR`, `LEADER`, or `ADMIN` must be granted by an administrator after registration. A privileged user can promote members by updating their role through the management tooling or by calling `UserRepository::update` in custom workflows.

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -72,7 +72,7 @@ class AuthController
         $email = trim($_POST['email'] ?? '');
         $password = $_POST['password'] ?? '';
         $display = trim($_POST['display_name'] ?? '');
-        $role = 'guild_member'; // Elevated roles must be granted by an administrator
+        $role = 'MEMBER'; // Elevated roles must be granted by an administrator
         $gameRole = $_POST['game_role'] ?? '';
         if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
             http_response_code(400);

--- a/src/Controllers/GuildController.php
+++ b/src/Controllers/GuildController.php
@@ -57,8 +57,8 @@ class GuildController
         }
         $this->guilds->registerGuild($leaderId, $name);
         $users = new \App\Repositories\UserRepository();
-        $users->update($_SESSION['user']['email'], ['role' => 'guild_leader']);
-        $_SESSION['user']['role'] = 'guild_leader';
+        $users->update($_SESSION['user']['email'], ['role' => 'LEADER']);
+        $_SESSION['user']['role'] = 'LEADER';
         header('Location: /');
         exit;
     }

--- a/src/Controllers/ManagementController.php
+++ b/src/Controllers/ManagementController.php
@@ -77,7 +77,7 @@ class ManagementController
             exit;
         }
         $guild = $this->guilds->getGuild((int)$membership['guild_id']);
-        if ($user['role'] !== 'admin' && (int)$guild['leader_id'] !== (int)$user['id']) {
+        if ($user['role'] !== 'ADMIN' && (int)$guild['leader_id'] !== (int)$user['id']) {
             http_response_code(403);
             $_SESSION['error'] = 'Forbidden';
             header('Location: /management');

--- a/src/Controllers/ProfileController.php
+++ b/src/Controllers/ProfileController.php
@@ -63,7 +63,7 @@ class ProfileController
         $guildId = (int)($_POST['guild_id'] ?? 0);
         if ($guildId) {
             $this->guilds->joinGuild($user['id'], $guildId);
-            $_SESSION['user']['role'] = 'guild_member';
+            $_SESSION['user']['role'] = 'MEMBER';
         }
         header('Location: /profile');
         exit;
@@ -73,8 +73,8 @@ class ProfileController
     {
         $user = $_SESSION['user'];
         $this->guilds->leaveGuild($user['id']);
-        $this->users->update($user['email'], ['role' => 'guild_member']);
-        $_SESSION['user']['role'] = 'guild_member';
+        $this->users->update($user['email'], ['role' => 'MEMBER']);
+        $_SESSION['user']['role'] = 'MEMBER';
         header('Location: /profile');
         exit;
     }

--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -29,7 +29,7 @@ class AuthService
         return null;
     }
 
-    public function register(string $email, string $password, string $displayName, string $gameRole, string $role = 'guild_member'): bool
+    public function register(string $email, string $password, string $displayName, string $gameRole, string $role = 'MEMBER'): bool
     {
         if (!$email || !$password || $this->users->findByEmail($email)) {
             return false;

--- a/src/config/permissions.php
+++ b/src/config/permissions.php
@@ -1,7 +1,7 @@
 <?php
 return [
-    'admin' => ['*'],
-    'guild_leader' => ['manage', 'view'],
-    'guild_advisor' => ['manage', 'view'],
-    'guild_member' => ['view']
+    'ADMIN' => ['*'],
+    'LEADER' => ['manage', 'view'],
+    'ADVISOR' => ['manage', 'view'],
+    'MEMBER' => ['view']
 ];

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -34,7 +34,7 @@ return [
     '/guilds' => [
         'GET' => function () use ($requireLogin, $guild, $user) {
             $requireLogin();
-            if ($user['role'] !== 'admin') {
+            if ($user['role'] !== 'ADMIN') {
                 http_response_code(403);
                 $message = 'Forbidden';
                 include __DIR__ . '/../views/errors/error.php';
@@ -86,7 +86,7 @@ return [
     '/management' => [
         'GET' => function () use ($requireLogin, $user, $management) {
             $requireLogin();
-            if (!in_array($user['role'], ['admin', 'guild_leader', 'guild_advisor'])) {
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
                 http_response_code(403);
                 $message = 'Forbidden';
                 include __DIR__ . '/../views/errors/error.php';
@@ -98,7 +98,7 @@ return [
     '/management/motd' => [
         'POST' => function () use ($requireLogin, $user, $management) {
             $requireLogin();
-            if ($user['role'] === 'guild_member') {
+            if ($user['role'] === 'MEMBER') {
                 http_response_code(403);
                 $message = 'Forbidden';
                 include __DIR__ . '/../views/errors/error.php';

--- a/src/views/auth/register.php
+++ b/src/views/auth/register.php
@@ -20,10 +20,10 @@ ob_start();
 
     <label for="register-game-role">In-game Role:</label>
     <select id="register-game-role" name="game_role">
-        <option value="tank" <?= ($values['game_role'] ?? '') === 'tank' ? 'selected' : '' ?>>Tank</option>
-        <option value="dps" <?= ($values['game_role'] ?? '') === 'dps' ? 'selected' : '' ?>>DPS</option>
-        <option value="ranged dps" <?= ($values['game_role'] ?? '') === 'ranged dps' ? 'selected' : '' ?>>Ranged DPS</option>
-        <option value="healer" <?= ($values['game_role'] ?? '') === 'healer' ? 'selected' : '' ?>>Healer</option>
+        <option value="TANK" <?= ($values['game_role'] ?? '') === 'TANK' ? 'selected' : '' ?>>Tank</option>
+        <option value="MELEE_DPS" <?= ($values['game_role'] ?? '') === 'MELEE_DPS' ? 'selected' : '' ?>>Melee DPS</option>
+        <option value="RANGED_DPS" <?= ($values['game_role'] ?? '') === 'RANGED_DPS' ? 'selected' : '' ?>>Ranged DPS</option>
+        <option value="HEALER" <?= ($values['game_role'] ?? '') === 'HEALER' ? 'selected' : '' ?>>Healer</option>
     </select>
     <span class="error" data-error="game_role" style="color:red"><?= htmlspecialchars($errors['game_role'] ?? '') ?></span><br>
 

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -34,11 +34,11 @@ $user = $user ?? ($_SESSION['user'] ?? null);
                 <li class="nav-item"><a class="nav-link <?= $currentPage === 'event-history' ? 'active' : '' ?>" href="/event-history">Event History</a></li>
                 <?php if ($user): ?>
                     <li class="nav-item"><a class="nav-link <?= $currentPage === 'profile' ? 'active' : '' ?>" href="/profile">Profile</a></li>
-                    <?php if (in_array($user['role'], ['admin', 'guild_leader', 'guild_advisor'])): ?>
+                    <?php if (in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])): ?>
                         <li class="nav-item"><a class="nav-link <?= $currentPage === 'management' ? 'active' : '' ?>" href="/management">Management</a></li>
                     <?php endif; ?>
                     <li class="nav-item"><a class="nav-link <?= $currentPage === 'guild_register' ? 'active' : '' ?>" href="/guild/register">New Guild</a></li>
-                    <?php if ($user['role'] === 'admin'): ?>
+                    <?php if ($user['role'] === 'ADMIN'): ?>
                         <li class="nav-item"><a class="nav-link <?= $currentPage === 'guilds' ? 'active' : '' ?>" href="/guilds">Guilds</a></li>
                     <?php endif; ?>
                     <li class="nav-item"><a class="nav-link" href="/logout">Logout</a></li>

--- a/src/views/profile/index.php
+++ b/src/views/profile/index.php
@@ -12,8 +12,8 @@ ob_start();
     <input type="text" id="profile-display-name" name="display_name" value="<?= htmlspecialchars($user['display_name']) ?>" required><br>
     <label for="profile-game-role">In-game Role:</label>
     <select id="profile-game-role" name="game_role">
-        <?php $roles = ['tank'=>'Tank','dps'=>'DPS','ranged dps'=>'Ranged DPS','healer'=>'Healer']; foreach($roles as $value => $label): ?>
-        <option value="<?= $value ?>"<?= $user['game_role']===$value?' selected':'' ?>><?= $label ?></option>
+        <?php $roles = ['TANK'=>'Tank','MELEE_DPS'=>'Melee DPS','RANGED_DPS'=>'Ranged DPS','HEALER'=>'Healer']; foreach($roles as $value => $label): ?>
+        <option value="<?= $value ?>"<?= $user['game_role'] === $value ? ' selected' : '' ?>><?= $label ?></option>
         <?php endforeach; ?>
     </select><br>
     <button type="submit">Save</button>

--- a/tests/Feature/AuthFeatureTest.php
+++ b/tests/Feature/AuthFeatureTest.php
@@ -38,8 +38,8 @@ class AuthFeatureTest extends TestCase
         $email = 'user@example.com';
         $password = 'secret';
         $display = 'User';
-        $role = 'guild_member';
-        $gameRole = 'mage';
+        $role = 'MEMBER';
+        $gameRole = 'HEALER';
 
         $this->assertTrue($this->auth->register($email, $password, $display, $gameRole, $role));
 
@@ -52,8 +52,8 @@ class AuthFeatureTest extends TestCase
     {
         $email = 'user@example.com';
         $password = 'secret';
-        $this->assertTrue($this->auth->register($email, $password, 'User', 'mage', 'guild_member'));
-        $this->assertFalse($this->auth->register($email, $password, 'User', 'mage', 'guild_member'));
+        $this->assertTrue($this->auth->register($email, $password, 'User', 'HEALER', 'MEMBER'));
+        $this->assertFalse($this->auth->register($email, $password, 'User', 'HEALER', 'MEMBER'));
     }
 }
 

--- a/tests/Unit/AuthServiceTest.php
+++ b/tests/Unit/AuthServiceTest.php
@@ -30,8 +30,8 @@ class AuthServiceTest extends TestCase
                 'id' => 1,
                 'password' => $hash,
                 'display_name' => 'User',
-                'role' => 'admin',
-                'game_role' => 'mage'
+                'role' => 'ADMIN',
+                'game_role' => 'HEALER'
             ]);
 
         $result = $this->auth->login($email, $password);
@@ -71,8 +71,8 @@ class AuthServiceTest extends TestCase
         $email = 'user@example.com';
         $password = 'secret';
         $display = 'User';
-        $role = 'guild_member';
-        $gameRole = 'mage';
+        $role = 'MEMBER';
+        $gameRole = 'HEALER';
 
         $this->users->expects($this->once())
             ->method('findByEmail')
@@ -97,7 +97,7 @@ class AuthServiceTest extends TestCase
         $email = 'new@example.com';
         $password = 'secret';
         $display = 'New';
-        $gameRole = 'mage';
+        $gameRole = 'HEALER';
 
         $this->users->expects($this->once())
             ->method('findByEmail')
@@ -110,7 +110,7 @@ class AuthServiceTest extends TestCase
                 $email,
                 $this->callback(fn($hash) => password_verify($password, $hash)),
                 $display,
-                'guild_member',
+                'MEMBER',
                 $gameRole
             );
 
@@ -122,8 +122,8 @@ class AuthServiceTest extends TestCase
         $email = 'user@example.com';
         $password = 'secret';
         $display = 'User';
-        $role = 'guild_member';
-        $gameRole = 'mage';
+        $role = 'MEMBER';
+        $gameRole = 'HEALER';
 
         $this->users->expects($this->once())
             ->method('findByEmail')


### PR DESCRIPTION
## Summary
- Match application role names to database enums (ADMIN, LEADER, ADVISOR, MEMBER)
- Align game role options (TANK, MELEE_DPS, RANGED_DPS, HEALER) and update navigation/permissions
- Update tests and docs for new role constants

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a5d00da22c832c926fc513a52e448e