### PR TITLE
Handle database errors in GuildService

### DIFF
--- a/src/Services/GuildService.php
+++ b/src/Services/GuildService.php
@@ -56,12 +56,20 @@ class GuildService
 
     public function getActiveMembership(int $userId): ?array
     {
-        return $this->guilds->getActiveMembership($userId);
+        try {
+            return $this->guilds->getActiveMembership($userId);
+        } catch (\PDOException $e) {
+            return null;
+        }
     }
 
     public function getGuild(int $id): ?array
     {
-        return $this->guilds->getGuild($id);
+        try {
+            return $this->guilds->getGuild($id);
+        } catch (\PDOException $e) {
+            return null;
+        }
     }
 
     public function setMotd(int $guildId, string $motd): void

--- a/tests/Unit/GuildServiceTest.php
+++ b/tests/Unit/GuildServiceTest.php
@@ -120,4 +120,26 @@ class GuildServiceTest extends TestCase
 
         $service->setMotd(3, 'Be brave');
     }
+
+    public function testGetActiveMembershipHandlesDatabaseExceptions(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->method('getActiveMembership')
+            ->willThrowException(new \PDOException('DB error'));
+
+        $this->assertNull($service->getActiveMembership(1));
+    }
+
+    public function testGetGuildHandlesDatabaseExceptions(): void
+    {
+        $repo = $this->createMock(GuildRepository::class);
+        $service = new GuildService($repo);
+
+        $repo->method('getGuild')
+            ->willThrowException(new \PDOException('DB error'));
+
+        $this->assertNull($service->getGuild(1));
+    }
 }


### PR DESCRIPTION
## Summary
- gracefully handle PDOExceptions in GuildService lookups to avoid 500s when database is down
- add unit tests covering new exception handling

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a5d5a0eb94832cb4ca3a5e29b7f54c