### PR TITLE
Add diagnostic script to check for missing autoload or route files

### DIFF
--- a/public/diag.php
+++ b/public/diag.php
@@ -1,0 +1,41 @@
+<?php
+// Show errors
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+header('Content-Type: text/plain');
+
+echo "Diag start\n\n";
+
+// Resolve paths relative to /public
+$base = __DIR__ . '/..'; // this should be /home/.../public_html
+$vendor = $base . '/vendor/autoload.php';
+$routes = $base . '/src/routes/web.php';
+
+echo "Expected base: $base\n";
+echo "Check vendor: $vendor => " . (file_exists($vendor) ? "OK\n" : "MISSING\n");
+echo "Check routes: $routes => " . (file_exists($routes) ? "OK\n" : "MISSING\n");
+
+// Try requiring autoload safely
+if (file_exists($vendor)) {
+    echo "Including autoload...\n";
+    require_once $vendor;
+    echo "Autoload included OK\n";
+} else {
+    echo "ERROR: vendor/autoload.php not found.\n";
+    echo "FIX: Run 'composer install' in the project root (one level above /public), or upload the /vendor folder.\n";
+    exit;
+}
+
+// Try requiring routes
+if (file_exists($routes)) {
+    echo "Including routes...\n";
+    $routesArr = require $routes;
+    echo "Routes loaded: " . (is_array($routesArr) ? count($routesArr) . " entries\n" : "unexpected type\n");
+} else {
+    echo "ERROR: src/routes/web.php not found at expected path.\n";
+    echo "Check your directory structure and the relative path in index.php\n";
+    exit;
+}
+
+echo "\nDiag done. If this page works, the 500 is likely inside one of your controllers.\n";
+?>


### PR DESCRIPTION
## Summary
- add `public/diag.php` to verify autoload and routes paths and surface configuration issues

## Testing
- `composer test`
- `php public/diag.php | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a5e74a608c832c8b6ea46621b0d6f3