### PR TITLE
Refresh site styling with modern theme

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,39 +1,51 @@
-/* Modern fantasy-inspired styling for DKP Site */
+/* Modern minimal styling for DKP Site */
+
+:root {
+    --color-bg-start: #f9fafb;
+    --color-bg-end: #e5e7eb;
+    --color-text: #1f2937;
+    --color-accent: #2563eb;
+    --color-accent-hover: #3b82f6;
+    --color-border: #e5e7eb;
+    --color-muted: #6b7280;
+}
 
 .site-body {
-    font-family: 'Roboto', sans-serif;
+    font-family: 'Inter', sans-serif;
     margin: 0;
     padding: 0;
-    background: linear-gradient(180deg, #0d0d0d 0%, #1a1a1a 100%);
-    color: #e0e0e0;
+    background: linear-gradient(180deg, var(--color-bg-start) 0%, var(--color-bg-end) 100%);
+    color: var(--color-text);
     min-height: 100vh;
     display: flex;
     flex-direction: column;
 }
 
 .site-header {
-    background-color: #1e1e1e;
-    border-bottom: 3px solid #c9a227;
+    background-color: #ffffff;
+    border-bottom: 1px solid var(--color-border);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .site-logo {
-    font-family: 'Cinzel', serif;
-    color: #c9a227;
+    font-family: 'Poppins', sans-serif;
+    font-weight: 600;
+    color: var(--color-accent);
 }
 
 .site-header .navbar-nav .nav-link {
-    color: #e0e0e0;
+    color: var(--color-text);
     transition: color 0.2s;
 }
 
 .site-header .navbar-nav .nav-link:hover,
 .site-header .navbar-nav .nav-link:focus {
-    color: #c9a227;
+    color: var(--color-accent);
     outline: none;
 }
 
 .site-header .navbar-nav .nav-link.active {
-    border-bottom: 2px solid #c9a227;
+    border-bottom: 2px solid var(--color-accent);
 }
 
 .site-main {
@@ -44,33 +56,35 @@
 .site-footer {
     text-align: center;
     padding: 1rem;
-    background-color: #1e1e1e;
-    border-top: 3px solid #c9a227;
+    background-color: #ffffff;
+    border-top: 1px solid var(--color-border);
+    color: var(--color-muted);
 }
 
 h1, h2, h3 {
-    font-family: 'Cinzel', serif;
-    color: #e0e0e0;
+    font-family: 'Poppins', sans-serif;
+    color: var(--color-text);
 }
 
 button {
-    background-color: #c9a227;
-    color: #1a1a1a;
+    background-color: var(--color-accent);
+    color: #ffffff;
     border: none;
+    border-radius: 0.375rem;
     padding: 0.5rem 1rem;
     cursor: pointer;
-    font-family: 'Roboto', sans-serif;
+    font-family: 'Inter', sans-serif;
 }
 
 button:hover,
 button:focus {
-    background-color: #e0c15f;
+    background-color: var(--color-accent-hover);
 }
 
 button:focus,
 input:focus,
 select:focus {
-    outline: 2px solid #c9a227;
+    outline: 2px solid var(--color-accent);
     outline-offset: 2px;
 }
 

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -15,12 +15,12 @@ $user = $user ?? ($_SESSION['user'] ?? null);
     <title><?= htmlspecialchars($title) ?></title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@600&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="site-body">
-<nav class="navbar navbar-expand-lg navbar-dark site-header" aria-label="Primary navigation">
+<nav class="navbar navbar-expand-lg navbar-light site-header" aria-label="Primary navigation">
     <div class="container-fluid">
         <a class="navbar-brand site-logo" href="/">DKP Site</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
## Summary
- Revamp layout to use Inter and Poppins fonts with light navbar styling
- Introduce new color palette and modern components via CSS variables

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a6daf3a9ec832cafad58dd4af63c54