### PR TITLE
Add management features for events and auctions

### DIFF
--- a/src/Controllers/ManagementController.php
+++ b/src/Controllers/ManagementController.php
@@ -57,6 +57,9 @@ class ManagementController
         $eventPage = min($eventPage, $eventPages);
         $eventItems = array_slice($eventItems, ($eventPage - 1) * $perPage, $perPage);
 
+        $defaultMinBid = $_SESSION['default_min_bid'] ?? 0;
+        $defaultAuctionTime = $_SESSION['default_auction_time'] ?? 60;
+
         include __DIR__ . '/../views/management/index.php';
     }
 
@@ -85,6 +88,138 @@ class ManagementController
         }
         $this->guilds->setMotd((int)$membership['guild_id'], $motd);
         $_SESSION['success'] = 'Message of the day updated';
+        header('Location: /management');
+        exit;
+    }
+
+    public function addEvent(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $name = trim($_POST['name'] ?? '');
+        $date = $_POST['date'] ?? date('Y-m-d');
+        $loot = array_filter(array_map('trim', explode(',', $_POST['loot'] ?? '')));
+        $event = $this->events->create($name, $date, $loot);
+        $minBid = $_SESSION['default_min_bid'] ?? 0;
+        $duration = $_SESSION['default_auction_time'] ?? 60;
+        foreach ($event['loot'] as $item) {
+            $this->auctions->create($item, $event['id'], $minBid, $duration);
+        }
+        $_SESSION['success'] = 'Event added';
+        header('Location: /management');
+        exit;
+    }
+
+    public function deleteEvent(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $id = (int)($_POST['id'] ?? 0);
+        $this->events->delete($id);
+        $_SESSION['success'] = 'Event deleted';
+        header('Location: /management');
+        exit;
+    }
+
+    public function updateAuctionSettings(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $_SESSION['default_min_bid'] = (float)($_POST['default_min_bid'] ?? 0);
+        $_SESSION['default_auction_time'] = (int)($_POST['default_auction_time'] ?? 60);
+        $_SESSION['success'] = 'Auction settings updated';
+        header('Location: /management');
+        exit;
+    }
+
+    public function closeAuction(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $id = (int)($_POST['id'] ?? 0);
+        $this->auctions->close($id);
+        $_SESSION['success'] = 'Auction closed';
+        header('Location: /management');
+        exit;
+    }
+
+    public function deleteAuction(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $id = (int)($_POST['id'] ?? 0);
+        $this->auctions->delete($id);
+        $_SESSION['success'] = 'Auction deleted';
+        header('Location: /management');
+        exit;
+    }
+
+    public function setAuctionWinner(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $id = (int)($_POST['id'] ?? 0);
+        $winner = trim($_POST['winner'] ?? '');
+        if ($winner !== '') {
+            $this->auctions->setWinner($id, $winner);
+            $_SESSION['success'] = 'Winner set';
+        }
+        header('Location: /management');
+        exit;
+    }
+
+    public function setAuctionMinBid(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $id = (int)($_POST['id'] ?? 0);
+        $minBid = (float)($_POST['min_bid'] ?? 0);
+        $this->auctions->setMinBid($id, $minBid);
+        $_SESSION['success'] = 'Minimum bid updated';
+        header('Location: /management');
+        exit;
+    }
+
+    public function setAuctionTime(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $id = (int)($_POST['id'] ?? 0);
+        $end = strtotime($_POST['end_time'] ?? '') ?: time();
+        $this->auctions->setEndTime($id, $end);
+        $_SESSION['success'] = 'Auction time updated';
         header('Location: /management');
         exit;
     }

--- a/src/Repositories/AuctionRepository.php
+++ b/src/Repositories/AuctionRepository.php
@@ -12,11 +12,102 @@ class AuctionRepository
                     'id' => $i,
                     'item' => 'Item ' . $i,
                     'status' => $i % 2 ? 'open' : 'closed',
-                    'created_at' => date('Y-m-d', strtotime("-{$i} days"))
+                    'created_at' => date('Y-m-d', strtotime("-{$i} days")),
+                    'min_bid' => 0,
+                    'end_time' => time() + 3600,
+                    'winner' => null,
+                    'event_id' => null,
                 ];
             }
             $_SESSION['auctions'] = $auctions;
         }
         return $auctions;
+    }
+
+    private function save(array $auctions): void
+    {
+        $_SESSION['auctions'] = $auctions;
+    }
+
+    private function findIndex(int $id): ?int
+    {
+        foreach ($this->all() as $index => $auction) {
+            if ((int)$auction['id'] === $id) {
+                return $index;
+            }
+        }
+        return null;
+    }
+
+    public function find(int $id): ?array
+    {
+        $index = $this->findIndex($id);
+        return $index !== null ? $this->all()[$index] : null;
+    }
+
+    public function create(string $item, int $eventId = null, float $minBid = 0, int $durationMinutes = 60): array
+    {
+        $auctions = $this->all();
+        $id = $auctions ? max(array_column($auctions, 'id')) + 1 : 1;
+        $auction = [
+            'id' => $id,
+            'item' => $item,
+            'status' => 'open',
+            'created_at' => date('Y-m-d H:i:s'),
+            'min_bid' => $minBid,
+            'end_time' => time() + ($durationMinutes * 60),
+            'winner' => null,
+            'event_id' => $eventId,
+        ];
+        $auctions[] = $auction;
+        $this->save($auctions);
+        return $auction;
+    }
+
+    public function close(int $id): void
+    {
+        $index = $this->findIndex($id);
+        if ($index !== null) {
+            $auctions = $this->all();
+            $auctions[$index]['status'] = 'closed';
+            $this->save($auctions);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $auctions = array_values(array_filter($this->all(), fn($a) => (int)$a['id'] !== $id));
+        $this->save($auctions);
+    }
+
+    public function setWinner(int $id, string $winner): void
+    {
+        $index = $this->findIndex($id);
+        if ($index !== null) {
+            $auctions = $this->all();
+            $auctions[$index]['winner'] = $winner;
+            $auctions[$index]['status'] = 'closed';
+            $this->save($auctions);
+        }
+    }
+
+    public function setMinBid(int $id, float $minBid): void
+    {
+        $index = $this->findIndex($id);
+        if ($index !== null) {
+            $auctions = $this->all();
+            $auctions[$index]['min_bid'] = $minBid;
+            $this->save($auctions);
+        }
+    }
+
+    public function setEndTime(int $id, int $timestamp): void
+    {
+        $index = $this->findIndex($id);
+        if ($index !== null) {
+            $auctions = $this->all();
+            $auctions[$index]['end_time'] = $timestamp;
+            $this->save($auctions);
+        }
     }
 }

--- a/src/Repositories/EventRepository.php
+++ b/src/Repositories/EventRepository.php
@@ -11,11 +11,38 @@ class EventRepository
                 $events[] = [
                     'id' => $i,
                     'name' => 'Event ' . $i,
-                    'date' => date('Y-m-d', strtotime("-{$i} days"))
+                    'date' => date('Y-m-d', strtotime("-{$i} days")),
+                    'loot' => [],
                 ];
             }
             $_SESSION['events'] = $events;
         }
         return $events;
+    }
+
+    private function save(array $events): void
+    {
+        $_SESSION['events'] = $events;
+    }
+
+    public function create(string $name, string $date, array $loot = []): array
+    {
+        $events = $this->all();
+        $id = $events ? max(array_column($events, 'id')) + 1 : 1;
+        $event = [
+            'id' => $id,
+            'name' => $name,
+            'date' => $date,
+            'loot' => $loot,
+        ];
+        $events[] = $event;
+        $this->save($events);
+        return $event;
+    }
+
+    public function delete(int $id): void
+    {
+        $events = array_values(array_filter($this->all(), fn($e) => (int)$e['id'] !== $id));
+        $this->save($events);
     }
 }

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -136,4 +136,100 @@ return [
             }
         },
     ],
+    '/management/event-add' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->addEvent();
+            }
+        },
+    ],
+    '/management/event-delete' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->deleteEvent();
+            }
+        },
+    ],
+    '/management/auction-settings' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->updateAuctionSettings();
+            }
+        },
+    ],
+    '/management/auction-close' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->closeAuction();
+            }
+        },
+    ],
+    '/management/auction-delete' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->deleteAuction();
+            }
+        },
+    ],
+    '/management/auction-winner' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->setAuctionWinner();
+            }
+        },
+    ],
+    '/management/auction-minbid' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->setAuctionMinBid();
+            }
+        },
+    ],
+    '/management/auction-time' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if (!in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])) {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->setAuctionTime();
+            }
+        },
+    ],
 ];

--- a/src/views/management/index.php
+++ b/src/views/management/index.php
@@ -14,6 +14,14 @@ ob_start();
 </form>
 <?php endif; ?>
 
+<h2>Auction Settings</h2>
+<form method="post" action="/management/auction-settings">
+    <?= \App\Helpers\Csrf::inputField() ?>
+    <label>Default Min Bid: <input type="number" name="default_min_bid" value="<?= htmlspecialchars($defaultMinBid) ?>"></label>
+    <label>Default Duration (minutes): <input type="number" name="default_auction_time" value="<?= htmlspecialchars($defaultAuctionTime) ?>"></label>
+    <button type="submit">Save</button>
+</form>
+
 <h2>Auctions</h2>
 <table>
     <thead>
@@ -21,6 +29,10 @@ ob_start();
             <th><a href="?auction_sort=id&auction_dir=<?= $auctionSort === 'id' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
             <th><a href="?auction_sort=item&auction_dir=<?= $auctionSort === 'item' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">Item</a></th>
             <th><a href="?auction_sort=status&auction_dir=<?= $auctionSort === 'status' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">Status</a></th>
+            <th>Min Bid</th>
+            <th>Ends</th>
+            <th>Winner</th>
+            <th>Actions</th>
         </tr>
     </thead>
     <tbody>
@@ -29,6 +41,39 @@ ob_start();
             <td><?= htmlspecialchars($auction['id']) ?></td>
             <td><?= htmlspecialchars($auction['item']) ?></td>
             <td><?= htmlspecialchars($auction['status']) ?></td>
+            <td><?= htmlspecialchars($auction['min_bid']) ?></td>
+            <td><?= date('Y-m-d H:i', $auction['end_time']) ?></td>
+            <td><?= htmlspecialchars($auction['winner'] ?? '') ?></td>
+            <td>
+                <form method="post" action="/management/auction-close" style="display:inline">
+                    <?= \App\Helpers\Csrf::inputField() ?>
+                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                    <button type="submit">Close</button>
+                </form>
+                <form method="post" action="/management/auction-delete" style="display:inline">
+                    <?= \App\Helpers\Csrf::inputField() ?>
+                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                    <button type="submit">Delete</button>
+                </form>
+                <form method="post" action="/management/auction-winner" style="display:inline">
+                    <?= \App\Helpers\Csrf::inputField() ?>
+                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                    <input type="text" name="winner" placeholder="Winner" value="<?= htmlspecialchars($auction['winner'] ?? '') ?>">
+                    <button type="submit">Set</button>
+                </form>
+                <form method="post" action="/management/auction-minbid" style="display:inline">
+                    <?= \App\Helpers\Csrf::inputField() ?>
+                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                    <input type="number" name="min_bid" value="<?= htmlspecialchars($auction['min_bid']) ?>">
+                    <button type="submit">Min Bid</button>
+                </form>
+                <form method="post" action="/management/auction-time" style="display:inline">
+                    <?= \App\Helpers\Csrf::inputField() ?>
+                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                    <input type="datetime-local" name="end_time" value="<?= date('Y-m-d\TH:i', $auction['end_time']) ?>">
+                    <button type="submit">Time</button>
+                </form>
+            </td>
         </tr>
         <?php endforeach; ?>
     </tbody>
@@ -44,12 +89,22 @@ ob_start();
 </div>
 
 <h2>Events</h2>
+<h3>Add Event</h3>
+<form method="post" action="/management/event-add">
+    <?= \App\Helpers\Csrf::inputField() ?>
+    <input type="text" name="name" placeholder="Name">
+    <input type="date" name="date" value="<?= date('Y-m-d') ?>">
+    <input type="text" name="loot" placeholder="Loot items comma separated">
+    <button type="submit">Add</button>
+</form>
 <table>
     <thead>
         <tr>
             <th><a href="?event_sort=id&event_dir=<?= $eventSort === 'id' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
             <th><a href="?event_sort=name&event_dir=<?= $eventSort === 'name' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">Name</a></th>
             <th><a href="?event_sort=date&event_dir=<?= $eventSort === 'date' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">Date</a></th>
+            <th>Loot</th>
+            <th>Actions</th>
         </tr>
     </thead>
     <tbody>
@@ -58,6 +113,14 @@ ob_start();
             <td><?= htmlspecialchars($event['id']) ?></td>
             <td><?= htmlspecialchars($event['name']) ?></td>
             <td><?= htmlspecialchars($event['date']) ?></td>
+            <td><?= htmlspecialchars(implode(', ', $event['loot'] ?? [])) ?></td>
+            <td>
+                <form method="post" action="/management/event-delete" style="display:inline">
+                    <?= \App\Helpers\Csrf::inputField() ?>
+                    <input type="hidden" name="id" value="<?= $event['id'] ?>">
+                    <button type="submit">Delete</button>
+                </form>
+            </td>
         </tr>
         <?php endforeach; ?>
     </tbody>

--- a/tests/Unit/AuctionRepositoryTest.php
+++ b/tests/Unit/AuctionRepositoryTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Tests\Unit;
+
+use App\Repositories\AuctionRepository;
+use PHPUnit\Framework\TestCase;
+
+class AuctionRepositoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+    }
+
+    public function testCreateAndUpdateAuction(): void
+    {
+        $repo = new AuctionRepository();
+        $auction = $repo->create('Sword', 1, 5, 60);
+        $this->assertSame('Sword', $auction['item']);
+        $repo->setMinBid($auction['id'], 10);
+        $repo->setEndTime($auction['id'], time() + 120);
+        $repo->setWinner($auction['id'], 'Alice');
+        $repo->close($auction['id']);
+        $repo->delete($auction['id']);
+        $this->assertNull($repo->find($auction['id']));
+    }
+}

--- a/tests/Unit/EventRepositoryTest.php
+++ b/tests/Unit/EventRepositoryTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace Tests\Unit;
+
+use App\Repositories\EventRepository;
+use PHPUnit\Framework\TestCase;
+
+class EventRepositoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+    }
+
+    public function testCreateAndDeleteEvent(): void
+    {
+        $repo = new EventRepository();
+        $event = $repo->create('Raid', '2024-01-01', ['Sword', 'Shield']);
+        $this->assertSame('Raid', $event['name']);
+        $repo->delete($event['id']);
+        $ids = array_column($repo->all(), 'id');
+        $this->assertNotContains($event['id'], $ids);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow creating and removing events with loot tracking
- Start and administer auctions with configurable settings
- Expose management actions via new routes and UI controls

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a6dc553548832cb4b227a6c8c432ab