### PR TITLE
Hide guild list for members and add admin guild controls

### DIFF
--- a/src/Controllers/ManagementController.php
+++ b/src/Controllers/ManagementController.php
@@ -27,6 +27,10 @@ class ManagementController
         if ($membership) {
             $currentGuild = $this->guilds->getGuild((int)$membership['guild_id']);
         }
+        $allGuilds = [];
+        if ($user['role'] === 'ADMIN') {
+            $allGuilds = $this->guilds->listGuilds();
+        }
 
         // Auctions
         $auctionPage = max(1, (int)($_GET['auction_page'] ?? 1));
@@ -220,6 +224,36 @@ class ManagementController
         $end = strtotime($_POST['end_time'] ?? '') ?: time();
         $this->auctions->setEndTime($id, $end);
         $_SESSION['success'] = 'Auction time updated';
+        header('Location: /management');
+        exit;
+    }
+
+    public function blockGuild(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $id = (int)($_POST['id'] ?? 0);
+        $this->guilds->blockGuild($id);
+        $_SESSION['success'] = 'Guild blocked';
+        header('Location: /management');
+        exit;
+    }
+
+    public function banGuild(): void
+    {
+        if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
+            http_response_code(400);
+            $_SESSION['error'] = 'Invalid CSRF token';
+            header('Location: /management');
+            exit;
+        }
+        $id = (int)($_POST['id'] ?? 0);
+        $this->guilds->banGuild($id);
+        $_SESSION['success'] = 'Guild banned';
         header('Location: /management');
         exit;
     }

--- a/src/Controllers/ProfileController.php
+++ b/src/Controllers/ProfileController.php
@@ -18,7 +18,6 @@ class ProfileController
     public function show(): void
     {
         $user = $_SESSION['user'];
-        $guilds = $this->guilds->listGuilds();
         $membership = $this->guilds->getActiveMembership($user['id']);
         $currentGuild = null;
         if ($membership) {

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -60,18 +60,6 @@ return [
             $guild->register();
         },
     ],
-    '/guilds' => [
-        'GET' => function () use ($requireLogin, $guild, $user) {
-            $requireLogin();
-            if ($user['role'] !== 'ADMIN') {
-                http_response_code(403);
-                $message = 'Forbidden';
-                include __DIR__ . '/../views/errors/error.php';
-            } else {
-                $guild->index();
-            }
-        },
-    ],
     '/auctions' => [
         'GET' => function () use ($requireLogin, $auction) {
             $requireLogin();
@@ -229,6 +217,30 @@ return [
                 include __DIR__ . '/../views/errors/error.php';
             } else {
                 $management->setAuctionTime();
+            }
+        },
+    ],
+    '/management/guild-block' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if ($user['role'] !== 'ADMIN') {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->blockGuild();
+            }
+        },
+    ],
+    '/management/guild-ban' => [
+        'POST' => function () use ($requireLogin, $user, $management) {
+            $requireLogin();
+            if ($user['role'] !== 'ADMIN') {
+                http_response_code(403);
+                $message = 'Forbidden';
+                include __DIR__ . '/../views/errors/error.php';
+            } else {
+                $management->banGuild();
             }
         },
     ],

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -6,6 +6,11 @@
 $title = $title ?? 'DKP Site';
 $currentPage = $currentPage ?? '';
 $user = $user ?? ($_SESSION['user'] ?? null);
+$membership = null;
+if ($user) {
+    $guildService = new \App\Services\GuildService();
+    $membership = $guildService->getActiveMembership($user['id']);
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -37,9 +42,8 @@ $user = $user ?? ($_SESSION['user'] ?? null);
                     <?php if (in_array($user['role'], ['ADMIN', 'LEADER', 'ADVISOR'])): ?>
                         <li class="nav-item"><a class="nav-link <?= $currentPage === 'management' ? 'active' : '' ?>" href="/management">Management</a></li>
                     <?php endif; ?>
-                    <li class="nav-item"><a class="nav-link <?= $currentPage === 'guild_register' ? 'active' : '' ?>" href="/guild/register">New Guild</a></li>
-                    <?php if ($user['role'] === 'ADMIN'): ?>
-                        <li class="nav-item"><a class="nav-link <?= $currentPage === 'guilds' ? 'active' : '' ?>" href="/guilds">Guilds</a></li>
+                    <?php if (!$membership): ?>
+                        <li class="nav-item"><a class="nav-link <?= $currentPage === 'guild_register' ? 'active' : '' ?>" href="/guild/register">New Guild</a></li>
                     <?php endif; ?>
                     <li class="nav-item"><a class="nav-link" href="/logout">Logout</a></li>
                 <?php else: ?>

--- a/src/views/management/index.php
+++ b/src/views/management/index.php
@@ -14,6 +14,32 @@ ob_start();
 </form>
 <?php endif; ?>
 
+<?php if ($user['role'] === 'ADMIN'): ?>
+<h2>Guilds</h2>
+<table>
+    <tr><th>ID</th><th>Name</th><th>Leader</th><th>Actions</th></tr>
+    <?php foreach ($allGuilds as $g): ?>
+    <tr>
+        <td><?= htmlspecialchars($g['id']) ?></td>
+        <td><?= htmlspecialchars($g['name']) ?></td>
+        <td><?= htmlspecialchars($g['leader_id']) ?></td>
+        <td>
+            <form method="post" action="/management/guild-block" style="display:inline">
+                <?= \App\Helpers\Csrf::inputField() ?>
+                <input type="hidden" name="id" value="<?= $g['id'] ?>">
+                <button type="submit">Block</button>
+            </form>
+            <form method="post" action="/management/guild-ban" style="display:inline">
+                <?= \App\Helpers\Csrf::inputField() ?>
+                <input type="hidden" name="id" value="<?= $g['id'] ?>">
+                <button type="submit">Ban</button>
+            </form>
+        </td>
+    </tr>
+    <?php endforeach; ?>
+</table>
+<?php endif; ?>
+
 <h2>Auction Settings</h2>
 <form method="post" action="/management/auction-settings">
     <?= \App\Helpers\Csrf::inputField() ?>

--- a/src/views/profile/index.php
+++ b/src/views/profile/index.php
@@ -19,7 +19,7 @@ ob_start();
     <button type="submit">Save</button>
 </form>
 
-<h2>Guilds</h2>
+<h2>Guild</h2>
 <?php if ($currentGuild): ?>
     <p>Current Guild: <?= htmlspecialchars($currentGuild['name']) ?></p>
     <form method="post" action="/profile/leave" style="display:inline">
@@ -28,20 +28,6 @@ ob_start();
 <?php else: ?>
     <p>Not currently in a guild.</p>
 <?php endif; ?>
-
-<ul>
-<?php foreach ($guilds as $g): ?>
-    <li>
-        <?= htmlspecialchars($g['name']) ?>
-        <?php if (!$currentGuild || $currentGuild['id'] !== $g['id']): ?>
-            <form method="post" action="/profile/join" style="display:inline">
-                <input type="hidden" name="guild_id" value="<?= $g['id'] ?>">
-                <button type="submit">Join</button>
-            </form>
-        <?php endif; ?>
-    </li>
-<?php endforeach; ?>
-</ul>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../layouts/main.php';


### PR DESCRIPTION
## Summary
- Hide "New Guild" navigation option when a user already belongs to a guild
- Simplify profile page to show only the current guild with option to leave
- Add guild listing and ban/block actions for administrators in Management, with routes

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a6defd7f88832cbcdb50b06b0ee358