### PR TITLE
Add role-aware collapsible management sidebar

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -117,8 +117,65 @@ select:focus {
         font-size: 1.5rem;
     }
 
-    h3 {
-        font-size: 1.25rem;
-    }
+h3 {
+    font-size: 1.25rem;
+}
+}
+
+/* Management page side navigation */
+.management-container {
+    display: flex;
+}
+
+.management-sidebar {
+    width: 220px;
+    background: #ffffff;
+    border-right: 1px solid var(--color-border);
+    transition: width 0.3s ease;
+}
+
+.management-sidebar.collapsed {
+    width: 60px;
+}
+
+.management-sidebar .toggle {
+    background: none;
+    border: none;
+    width: 100%;
+    text-align: right;
+    padding: 0.5rem;
+}
+
+.management-nav {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.management-nav li a {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.management-nav li a.active {
+    background-color: var(--color-bg-end);
+    font-weight: 600;
+}
+
+.management-sidebar.collapsed .text {
+    display: none;
+}
+
+.management-sidebar.collapsed .management-nav li a {
+    justify-content: center;
+}
+
+.management-main {
+    flex: 1;
+    padding: 0 1rem;
 }
 

--- a/public/js/management.js
+++ b/public/js/management.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('managementToggle');
+    const sidebar = document.querySelector('.management-sidebar');
+    if (toggle && sidebar) {
+        toggle.addEventListener('click', () => {
+            sidebar.classList.toggle('collapsed');
+        });
+    }
+});
+

--- a/src/Controllers/ManagementController.php
+++ b/src/Controllers/ManagementController.php
@@ -32,6 +32,13 @@ class ManagementController
             $allGuilds = $this->guilds->listGuilds();
         }
 
+        $guildMembers = [];
+        if ($currentGuild) {
+            $guildMembers = $this->guilds->listMembers((int)$currentGuild['id']);
+        }
+
+        $section = $_GET['section'] ?? 'motd';
+
         // Auctions
         $auctionPage = max(1, (int)($_GET['auction_page'] ?? 1));
         $auctionSort = $_GET['auction_sort'] ?? 'id';

--- a/src/Repositories/GuildRepository.php
+++ b/src/Repositories/GuildRepository.php
@@ -100,6 +100,25 @@ class GuildRepository
     }
 
     /**
+     * Retrieve active members for a guild.
+     *
+     * @param int $guildId
+     * @return array<int, array<string, mixed>>
+     */
+    public function getGuildMembers(int $guildId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT u.id, u.display_name, u.role, gm.joined_at
+             FROM guild_members gm
+             JOIN users u ON gm.user_id = u.id
+             WHERE gm.guild_id = :guild AND gm.left_at IS NULL
+             ORDER BY u.display_name'
+        );
+        $stmt->execute(['guild' => $guildId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
      * Mark a guild as blocked. The schema is expected to contain a `blocked`
      * column. This repository does not enforce the schema but issues the SQL
      * update so higher layers can flag a guild as suspended.

--- a/src/Services/GuildService.php
+++ b/src/Services/GuildService.php
@@ -103,6 +103,21 @@ class GuildService
     }
 
     /**
+     * Return active members of a guild.
+     *
+     * @param int $guildId
+     * @return array<int, array<string, mixed>>
+     */
+    public function listMembers(int $guildId): array
+    {
+        try {
+            return $this->guilds->getGuildMembers($guildId);
+        } catch (\PDOException $e) {
+            return [];
+        }
+    }
+
+    /**
      * Allow an administrator to join a guild either as a regular member or as
      * the leader. This bypasses the normal leader and cooldown checks.
      */

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -22,6 +22,7 @@ if ($user) {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@600&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="/css/main.css">
 </head>
 <body class="site-body">

--- a/src/views/management/index.php
+++ b/src/views/management/index.php
@@ -1,165 +1,215 @@
 <?php
 $title = 'Management';
 $currentPage = 'management';
+
+$navItems = [
+    ['id' => 'motd', 'label' => 'Message', 'icon' => 'bi-megaphone'],
+    ['id' => 'events', 'label' => 'Events', 'icon' => 'bi-calendar-event'],
+    ['id' => 'auctions', 'label' => 'Auctions', 'icon' => 'bi-hammer'],
+];
+if (in_array($user['role'], ['LEADER', 'ADMIN'])) {
+    $navItems[] = ['id' => 'members', 'label' => 'Members', 'icon' => 'bi-people'];
+}
+if ($user['role'] === 'ADMIN') {
+    $navItems[] = ['id' => 'guilds', 'label' => 'Guilds', 'icon' => 'bi-list-check'];
+}
+$allowedSections = array_column($navItems, 'id');
+$section = in_array($section, $allowedSections) ? $section : $allowedSections[0];
+
 ob_start();
 ?>
-<h1>Management</h1>
+<div class="management-container">
+    <aside class="management-sidebar">
+        <button id="managementToggle" class="toggle"><i class="bi bi-chevron-left"></i></button>
+        <ul class="management-nav">
+            <?php foreach ($navItems as $item): ?>
+                <li>
+                    <a href="/management?section=<?= $item['id'] ?>" class="<?= $section === $item['id'] ? 'active' : '' ?>">
+                        <i class="bi <?= $item['icon'] ?>"></i>
+                        <span class="text"><?= htmlspecialchars($item['label']) ?></span>
+                    </a>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    </aside>
+    <section class="management-main">
+        <?php if ($section === 'motd'): ?>
+            <?php if (!empty($currentGuild)): ?>
+                <h2>Message of the Day</h2>
+                <form method="post" action="/management/motd" id="motdForm">
+                    <?= \App\Helpers\Csrf::inputField() ?>
+                    <textarea name="motd" id="motd" rows="3" cols="50"><?= htmlspecialchars($currentGuild['motd'] ?? '') ?></textarea><br>
+                    <button type="submit">Save</button>
+                </form>
+            <?php else: ?>
+                <p>No guild available.</p>
+            <?php endif; ?>
 
-<?php if (!empty($currentGuild)): ?>
-<h2>Message of the Day</h2>
-<form method="post" action="/management/motd" id="motdForm">
-    <?= \App\Helpers\Csrf::inputField() ?>
-    <textarea name="motd" id="motd" rows="3" cols="50"><?= htmlspecialchars($currentGuild['motd'] ?? '') ?></textarea><br>
-    <button type="submit">Save</button>
-</form>
-<?php endif; ?>
+        <?php elseif ($section === 'guilds' && $user['role'] === 'ADMIN'): ?>
+            <h2>Guilds</h2>
+            <table>
+                <tr><th>ID</th><th>Name</th><th>Leader</th><th>Actions</th></tr>
+                <?php foreach ($allGuilds as $g): ?>
+                <tr>
+                    <td><?= htmlspecialchars($g['id']) ?></td>
+                    <td><?= htmlspecialchars($g['name']) ?></td>
+                    <td><?= htmlspecialchars($g['leader_id']) ?></td>
+                    <td>
+                        <form method="post" action="/management/guild-block" style="display:inline">
+                            <?= \App\Helpers\Csrf::inputField() ?>
+                            <input type="hidden" name="id" value="<?= $g['id'] ?>">
+                            <button type="submit">Block</button>
+                        </form>
+                        <form method="post" action="/management/guild-ban" style="display:inline">
+                            <?= \App\Helpers\Csrf::inputField() ?>
+                            <input type="hidden" name="id" value="<?= $g['id'] ?>">
+                            <button type="submit">Ban</button>
+                        </form>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </table>
 
-<?php if ($user['role'] === 'ADMIN'): ?>
-<h2>Guilds</h2>
-<table>
-    <tr><th>ID</th><th>Name</th><th>Leader</th><th>Actions</th></tr>
-    <?php foreach ($allGuilds as $g): ?>
-    <tr>
-        <td><?= htmlspecialchars($g['id']) ?></td>
-        <td><?= htmlspecialchars($g['name']) ?></td>
-        <td><?= htmlspecialchars($g['leader_id']) ?></td>
-        <td>
-            <form method="post" action="/management/guild-block" style="display:inline">
+        <?php elseif ($section === 'auctions'): ?>
+            <h2>Auction Settings</h2>
+            <form method="post" action="/management/auction-settings">
                 <?= \App\Helpers\Csrf::inputField() ?>
-                <input type="hidden" name="id" value="<?= $g['id'] ?>">
-                <button type="submit">Block</button>
+                <label>Default Min Bid: <input type="number" name="default_min_bid" value="<?= htmlspecialchars($defaultMinBid) ?>"></label>
+                <label>Default Duration (minutes): <input type="number" name="default_auction_time" value="<?= htmlspecialchars($defaultAuctionTime) ?>"></label>
+                <button type="submit">Save</button>
             </form>
-            <form method="post" action="/management/guild-ban" style="display:inline">
+
+            <h2>Auctions</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th><a href="?section=auctions&auction_sort=id&auction_dir=<?= $auctionSort === 'id' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
+                        <th><a href="?section=auctions&auction_sort=item&auction_dir=<?= $auctionSort === 'item' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">Item</a></th>
+                        <th><a href="?section=auctions&auction_sort=status&auction_dir=<?= $auctionSort === 'status' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">Status</a></th>
+                        <th>Min Bid</th>
+                        <th>Ends</th>
+                        <th>Winner</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($auctionItems as $auction): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($auction['id']) ?></td>
+                        <td><?= htmlspecialchars($auction['item']) ?></td>
+                        <td><?= htmlspecialchars($auction['status']) ?></td>
+                        <td><?= htmlspecialchars($auction['min_bid']) ?></td>
+                        <td><?= date('Y-m-d H:i', $auction['end_time']) ?></td>
+                        <td><?= htmlspecialchars($auction['winner'] ?? '') ?></td>
+                        <td>
+                            <form method="post" action="/management/auction-close" style="display:inline">
+                                <?= \App\Helpers\Csrf::inputField() ?>
+                                <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                                <button type="submit">Close</button>
+                            </form>
+                            <form method="post" action="/management/auction-delete" style="display:inline">
+                                <?= \App\Helpers\Csrf::inputField() ?>
+                                <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                                <button type="submit">Delete</button>
+                            </form>
+                            <form method="post" action="/management/auction-winner" style="display:inline">
+                                <?= \App\Helpers\Csrf::inputField() ?>
+                                <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                                <input type="text" name="winner" placeholder="Winner" value="<?= htmlspecialchars($auction['winner'] ?? '') ?>">
+                                <button type="submit">Set</button>
+                            </form>
+                            <form method="post" action="/management/auction-minbid" style="display:inline">
+                                <?= \App\Helpers\Csrf::inputField() ?>
+                                <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                                <input type="number" name="min_bid" value="<?= htmlspecialchars($auction['min_bid']) ?>">
+                                <button type="submit">Min Bid</button>
+                            </form>
+                            <form method="post" action="/management/auction-time" style="display:inline">
+                                <?= \App\Helpers\Csrf::inputField() ?>
+                                <input type="hidden" name="id" value="<?= $auction['id'] ?>">
+                                <input type="datetime-local" name="end_time" value="<?= date('Y-m-d\TH:i', $auction['end_time']) ?>">
+                                <button type="submit">Time</button>
+                            </form>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+            <div class="pagination">
+                <?php if ($auctionPage > 1): ?>
+                    <a href="?section=auctions&auction_page=<?= $auctionPage-1 ?>&auction_sort=<?= $auctionSort ?>&auction_dir=<?= $auctionDir ?>">Prev</a>
+                <?php endif; ?>
+                Page <?= $auctionPage ?> of <?= $auctionPages ?>
+                <?php if ($auctionPage < $auctionPages): ?>
+                    <a href="?section=auctions&auction_page=<?= $auctionPage+1 ?>&auction_sort=<?= $auctionSort ?>&auction_dir=<?= $auctionDir ?>">Next</a>
+                <?php endif; ?>
+            </div>
+
+        <?php elseif ($section === 'events'): ?>
+            <h2>Events</h2>
+            <h3>Add Event</h3>
+            <form method="post" action="/management/event-add">
                 <?= \App\Helpers\Csrf::inputField() ?>
-                <input type="hidden" name="id" value="<?= $g['id'] ?>">
-                <button type="submit">Ban</button>
+                <input type="text" name="name" placeholder="Name">
+                <input type="date" name="date" value="<?= date('Y-m-d') ?>">
+                <input type="text" name="loot" placeholder="Loot items comma separated">
+                <button type="submit">Add</button>
             </form>
-        </td>
-    </tr>
-    <?php endforeach; ?>
-</table>
-<?php endif; ?>
+            <table>
+                <thead>
+                    <tr>
+                        <th><a href="?section=events&event_sort=id&event_dir=<?= $eventSort === 'id' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
+                        <th><a href="?section=events&event_sort=name&event_dir=<?= $eventSort === 'name' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">Name</a></th>
+                        <th><a href="?section=events&event_sort=date&event_dir=<?= $eventSort === 'date' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">Date</a></th>
+                        <th>Loot</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($eventItems as $event): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($event['id']) ?></td>
+                        <td><?= htmlspecialchars($event['name']) ?></td>
+                        <td><?= htmlspecialchars($event['date']) ?></td>
+                        <td><?= htmlspecialchars(implode(', ', $event['loot'] ?? [])) ?></td>
+                        <td>
+                            <form method="post" action="/management/event-delete" style="display:inline">
+                                <?= \App\Helpers\Csrf::inputField() ?>
+                                <input type="hidden" name="id" value="<?= $event['id'] ?>">
+                                <button type="submit">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+            <div class="pagination">
+                <?php if ($eventPage > 1): ?>
+                    <a href="?section=events&event_page=<?= $eventPage-1 ?>&event_sort=<?= $eventSort ?>&event_dir=<?= $eventDir ?>">Prev</a>
+                <?php endif; ?>
+                Page <?= $eventPage ?> of <?= $eventPages ?>
+                <?php if ($eventPage < $eventPages): ?>
+                    <a href="?section=events&event_page=<?= $eventPage+1 ?>&event_sort=<?= $eventSort ?>&event_dir=<?= $eventDir ?>">Next</a>
+                <?php endif; ?>
+            </div>
 
-<h2>Auction Settings</h2>
-<form method="post" action="/management/auction-settings">
-    <?= \App\Helpers\Csrf::inputField() ?>
-    <label>Default Min Bid: <input type="number" name="default_min_bid" value="<?= htmlspecialchars($defaultMinBid) ?>"></label>
-    <label>Default Duration (minutes): <input type="number" name="default_auction_time" value="<?= htmlspecialchars($defaultAuctionTime) ?>"></label>
-    <button type="submit">Save</button>
-</form>
-
-<h2>Auctions</h2>
-<table>
-    <thead>
-        <tr>
-            <th><a href="?auction_sort=id&auction_dir=<?= $auctionSort === 'id' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
-            <th><a href="?auction_sort=item&auction_dir=<?= $auctionSort === 'item' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">Item</a></th>
-            <th><a href="?auction_sort=status&auction_dir=<?= $auctionSort === 'status' && $auctionDir === 'asc' ? 'desc' : 'asc' ?>">Status</a></th>
-            <th>Min Bid</th>
-            <th>Ends</th>
-            <th>Winner</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php foreach ($auctionItems as $auction): ?>
-        <tr>
-            <td><?= htmlspecialchars($auction['id']) ?></td>
-            <td><?= htmlspecialchars($auction['item']) ?></td>
-            <td><?= htmlspecialchars($auction['status']) ?></td>
-            <td><?= htmlspecialchars($auction['min_bid']) ?></td>
-            <td><?= date('Y-m-d H:i', $auction['end_time']) ?></td>
-            <td><?= htmlspecialchars($auction['winner'] ?? '') ?></td>
-            <td>
-                <form method="post" action="/management/auction-close" style="display:inline">
-                    <?= \App\Helpers\Csrf::inputField() ?>
-                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
-                    <button type="submit">Close</button>
-                </form>
-                <form method="post" action="/management/auction-delete" style="display:inline">
-                    <?= \App\Helpers\Csrf::inputField() ?>
-                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
-                    <button type="submit">Delete</button>
-                </form>
-                <form method="post" action="/management/auction-winner" style="display:inline">
-                    <?= \App\Helpers\Csrf::inputField() ?>
-                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
-                    <input type="text" name="winner" placeholder="Winner" value="<?= htmlspecialchars($auction['winner'] ?? '') ?>">
-                    <button type="submit">Set</button>
-                </form>
-                <form method="post" action="/management/auction-minbid" style="display:inline">
-                    <?= \App\Helpers\Csrf::inputField() ?>
-                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
-                    <input type="number" name="min_bid" value="<?= htmlspecialchars($auction['min_bid']) ?>">
-                    <button type="submit">Min Bid</button>
-                </form>
-                <form method="post" action="/management/auction-time" style="display:inline">
-                    <?= \App\Helpers\Csrf::inputField() ?>
-                    <input type="hidden" name="id" value="<?= $auction['id'] ?>">
-                    <input type="datetime-local" name="end_time" value="<?= date('Y-m-d\TH:i', $auction['end_time']) ?>">
-                    <button type="submit">Time</button>
-                </form>
-            </td>
-        </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
-<div class="pagination">
-    <?php if ($auctionPage > 1): ?>
-        <a href="?auction_page=<?= $auctionPage-1 ?>&auction_sort=<?= $auctionSort ?>&auction_dir=<?= $auctionDir ?>">Prev</a>
-    <?php endif; ?>
-    Page <?= $auctionPage ?> of <?= $auctionPages ?>
-    <?php if ($auctionPage < $auctionPages): ?>
-        <a href="?auction_page=<?= $auctionPage+1 ?>&auction_sort=<?= $auctionSort ?>&auction_dir=<?= $auctionDir ?>">Next</a>
-    <?php endif; ?>
+        <?php elseif ($section === 'members'): ?>
+            <h2>Guild Members</h2>
+            <table>
+                <tr><th>Name</th><th>Role</th><th>Joined</th></tr>
+                <?php foreach ($guildMembers as $m): ?>
+                <tr>
+                    <td><?= htmlspecialchars($m['display_name']) ?></td>
+                    <td><?= htmlspecialchars($m['role']) ?></td>
+                    <td><?= htmlspecialchars($m['joined_at']) ?></td>
+                </tr>
+                <?php endforeach; ?>
+            </table>
+        <?php endif; ?>
+    </section>
 </div>
-
-<h2>Events</h2>
-<h3>Add Event</h3>
-<form method="post" action="/management/event-add">
-    <?= \App\Helpers\Csrf::inputField() ?>
-    <input type="text" name="name" placeholder="Name">
-    <input type="date" name="date" value="<?= date('Y-m-d') ?>">
-    <input type="text" name="loot" placeholder="Loot items comma separated">
-    <button type="submit">Add</button>
-</form>
-<table>
-    <thead>
-        <tr>
-            <th><a href="?event_sort=id&event_dir=<?= $eventSort === 'id' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">ID</a></th>
-            <th><a href="?event_sort=name&event_dir=<?= $eventSort === 'name' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">Name</a></th>
-            <th><a href="?event_sort=date&event_dir=<?= $eventSort === 'date' && $eventDir === 'asc' ? 'desc' : 'asc' ?>">Date</a></th>
-            <th>Loot</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php foreach ($eventItems as $event): ?>
-        <tr>
-            <td><?= htmlspecialchars($event['id']) ?></td>
-            <td><?= htmlspecialchars($event['name']) ?></td>
-            <td><?= htmlspecialchars($event['date']) ?></td>
-            <td><?= htmlspecialchars(implode(', ', $event['loot'] ?? [])) ?></td>
-            <td>
-                <form method="post" action="/management/event-delete" style="display:inline">
-                    <?= \App\Helpers\Csrf::inputField() ?>
-                    <input type="hidden" name="id" value="<?= $event['id'] ?>">
-                    <button type="submit">Delete</button>
-                </form>
-            </td>
-        </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
-<div class="pagination">
-    <?php if ($eventPage > 1): ?>
-        <a href="?event_page=<?= $eventPage-1 ?>&event_sort=<?= $eventSort ?>&event_dir=<?= $eventDir ?>">Prev</a>
-    <?php endif; ?>
-    Page <?= $eventPage ?> of <?= $eventPages ?>
-    <?php if ($eventPage < $eventPages): ?>
-        <a href="?event_page=<?= $eventPage+1 ?>&event_sort=<?= $eventSort ?>&event_dir=<?= $eventDir ?>">Next</a>
-    <?php endif; ?>
-</div>
+<script src="/js/management.js"></script>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../layouts/main.php';
+


### PR DESCRIPTION
## Summary
- Replace monolithic management page with collapsible sidebar navigation that shows sections per user role
- Support listing guild members and admin guild list with new repository and service helpers
- Add styling, icons, and script for expandable sidebar

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e26fca70832cbfa76e2aa614cc6e