### PR TITLE
Use database for event and auction listings

### DIFF
--- a/src/Repositories/AuctionRepository.php
+++ b/src/Repositories/AuctionRepository.php
@@ -1,113 +1,114 @@
 <?php
 namespace App\Repositories;
 
+use App\Database;
+use PDO;
+
 class AuctionRepository
 {
+    private ?PDO $db = null;
+
+    public function __construct(?PDO $db = null)
+    {
+        $this->db = $db;
+    }
+
+    private function db(): PDO
+    {
+        if ($this->db === null) {
+            $this->db = Database::connection();
+        }
+        return $this->db;
+    }
+
     public function all(): array
     {
-        $auctions = $_SESSION['auctions'] ?? [];
-        if (!$auctions) {
-            for ($i = 1; $i <= 25; $i++) {
-                $auctions[] = [
-                    'id' => $i,
-                    'item' => 'Item ' . $i,
-                    'status' => $i % 2 ? 'open' : 'closed',
-                    'created_at' => date('Y-m-d', strtotime("-{$i} days")),
-                    'min_bid' => 0,
-                    'end_time' => time() + 3600,
-                    'winner' => null,
-                    'event_id' => null,
-                ];
-            }
-            $_SESSION['auctions'] = $auctions;
-        }
-        return $auctions;
-    }
-
-    private function save(array $auctions): void
-    {
-        $_SESSION['auctions'] = $auctions;
-    }
-
-    private function findIndex(int $id): ?int
-    {
-        foreach ($this->all() as $index => $auction) {
-            if ((int)$auction['id'] === $id) {
-                return $index;
-            }
-        }
-        return null;
+        $stmt = $this->db()->query('SELECT * FROM auctions ORDER BY created_at DESC');
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return array_map(function ($row) {
+            return [
+                'id' => (int)$row['id'],
+                'item' => $row['item_name'],
+                'status' => strtolower($row['status']),
+                'created_at' => $row['created_at'],
+                'min_bid' => (int)$row['min_bid'],
+                'end_time' => strtotime($row['ends_at']),
+                'winner' => $row['winner_user_id'],
+                'event_id' => $row['event_id'],
+            ];
+        }, $rows);
     }
 
     public function find(int $id): ?array
     {
-        $index = $this->findIndex($id);
-        return $index !== null ? $this->all()[$index] : null;
+        $stmt = $this->db()->prepare('SELECT * FROM auctions WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            return null;
+        }
+        return [
+            'id' => (int)$row['id'],
+            'item' => $row['item_name'],
+            'status' => strtolower($row['status']),
+            'created_at' => $row['created_at'],
+            'min_bid' => (int)$row['min_bid'],
+            'end_time' => strtotime($row['ends_at']),
+            'winner' => $row['winner_user_id'],
+            'event_id' => $row['event_id'],
+        ];
     }
 
-    public function create(string $item, int $eventId = null, float $minBid = 0, int $durationMinutes = 60): array
+    public function create(string $item, int $eventId, float $minBid = 0, int $durationMinutes = 60): array
     {
-        $auctions = $this->all();
-        $id = $auctions ? max(array_column($auctions, 'id')) + 1 : 1;
-        $auction = [
+        $end = time() + ($durationMinutes * 60);
+        $stmt = $this->db()->prepare('INSERT INTO auctions (event_id, item_name, min_bid, ends_at, status, created_at) VALUES (:event_id, :item, :min_bid, :ends_at, "OPEN", CURRENT_TIMESTAMP)');
+        $stmt->execute([
+            'event_id' => $eventId,
+            'item' => $item,
+            'min_bid' => $minBid,
+            'ends_at' => date('Y-m-d H:i:s', $end),
+        ]);
+        $id = (int)$this->db()->lastInsertId();
+        return [
             'id' => $id,
             'item' => $item,
             'status' => 'open',
             'created_at' => date('Y-m-d H:i:s'),
             'min_bid' => $minBid,
-            'end_time' => time() + ($durationMinutes * 60),
+            'end_time' => $end,
             'winner' => null,
             'event_id' => $eventId,
         ];
-        $auctions[] = $auction;
-        $this->save($auctions);
-        return $auction;
     }
 
     public function close(int $id): void
     {
-        $index = $this->findIndex($id);
-        if ($index !== null) {
-            $auctions = $this->all();
-            $auctions[$index]['status'] = 'closed';
-            $this->save($auctions);
-        }
+        $stmt = $this->db()->prepare('UPDATE auctions SET status = "CLOSED", closed_at = CURRENT_TIMESTAMP WHERE id = :id');
+        $stmt->execute(['id' => $id]);
     }
 
     public function delete(int $id): void
     {
-        $auctions = array_values(array_filter($this->all(), fn($a) => (int)$a['id'] !== $id));
-        $this->save($auctions);
+        $stmt = $this->db()->prepare('DELETE FROM auctions WHERE id = :id');
+        $stmt->execute(['id' => $id]);
     }
 
-    public function setWinner(int $id, string $winner): void
+    public function setWinner(int $id, int $winnerUserId): void
     {
-        $index = $this->findIndex($id);
-        if ($index !== null) {
-            $auctions = $this->all();
-            $auctions[$index]['winner'] = $winner;
-            $auctions[$index]['status'] = 'closed';
-            $this->save($auctions);
-        }
+        $stmt = $this->db()->prepare('UPDATE auctions SET winner_user_id = :winner, status = "CLOSED", closed_at = CURRENT_TIMESTAMP WHERE id = :id');
+        $stmt->execute(['winner' => $winnerUserId, 'id' => $id]);
     }
 
     public function setMinBid(int $id, float $minBid): void
     {
-        $index = $this->findIndex($id);
-        if ($index !== null) {
-            $auctions = $this->all();
-            $auctions[$index]['min_bid'] = $minBid;
-            $this->save($auctions);
-        }
+        $stmt = $this->db()->prepare('UPDATE auctions SET min_bid = :min_bid WHERE id = :id');
+        $stmt->execute(['min_bid' => $minBid, 'id' => $id]);
     }
 
     public function setEndTime(int $id, int $timestamp): void
     {
-        $index = $this->findIndex($id);
-        if ($index !== null) {
-            $auctions = $this->all();
-            $auctions[$index]['end_time'] = $timestamp;
-            $this->save($auctions);
-        }
+        $stmt = $this->db()->prepare('UPDATE auctions SET ends_at = :end WHERE id = :id');
+        $stmt->execute(['end' => date('Y-m-d H:i:s', $timestamp), 'id' => $id]);
     }
 }

--- a/src/Repositories/EventRepository.php
+++ b/src/Repositories/EventRepository.php
@@ -1,48 +1,60 @@
 <?php
 namespace App\Repositories;
 
+use App\Database;
+use PDO;
+
 class EventRepository
 {
-    public function all(): array
+    private ?PDO $db = null;
+
+    public function __construct(?PDO $db = null)
     {
-        $events = $_SESSION['events'] ?? [];
-        if (!$events) {
-            for ($i = 1; $i <= 30; $i++) {
-                $events[] = [
-                    'id' => $i,
-                    'name' => 'Event ' . $i,
-                    'date' => date('Y-m-d', strtotime("-{$i} days")),
-                    'loot' => [],
-                ];
-            }
-            $_SESSION['events'] = $events;
-        }
-        return $events;
+        $this->db = $db;
     }
 
-    private function save(array $events): void
+    private function db(): PDO
     {
-        $_SESSION['events'] = $events;
+        if ($this->db === null) {
+            $this->db = Database::connection();
+        }
+        return $this->db;
+    }
+
+    public function all(): array
+    {
+        $stmt = $this->db()->query('SELECT id, name, occurred_at, dropped_item FROM events ORDER BY occurred_at DESC');
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return array_map(function ($row) {
+            return [
+                'id' => (int)$row['id'],
+                'name' => $row['name'],
+                'date' => substr($row['occurred_at'], 0, 10),
+                'loot' => $row['dropped_item'] ? array_map('trim', explode(',', $row['dropped_item'])) : [],
+            ];
+        }, $rows);
     }
 
     public function create(string $name, string $date, array $loot = []): array
     {
-        $events = $this->all();
-        $id = $events ? max(array_column($events, 'id')) + 1 : 1;
-        $event = [
+        $stmt = $this->db()->prepare('INSERT INTO events (name, event_type_id, occurred_at, notes, dropped_item, created_by, created_at) VALUES (:name, 1, :occurred_at, NULL, :dropped, 1, CURRENT_TIMESTAMP)');
+        $stmt->execute([
+            'name' => $name,
+            'occurred_at' => $date . ' 00:00:00',
+            'dropped' => $loot ? implode(', ', $loot) : null,
+        ]);
+        $id = (int)$this->db()->lastInsertId();
+        return [
             'id' => $id,
             'name' => $name,
             'date' => $date,
             'loot' => $loot,
         ];
-        $events[] = $event;
-        $this->save($events);
-        return $event;
     }
 
     public function delete(int $id): void
     {
-        $events = array_values(array_filter($this->all(), fn($e) => (int)$e['id'] !== $id));
-        $this->save($events);
+        $stmt = $this->db()->prepare('DELETE FROM events WHERE id = :id');
+        $stmt->execute(['id' => $id]);
     }
 }

--- a/tests/Unit/AuctionRepositoryTest.php
+++ b/tests/Unit/AuctionRepositoryTest.php
@@ -2,25 +2,41 @@
 namespace Tests\Unit;
 
 use App\Repositories\AuctionRepository;
+use PDO;
 use PHPUnit\Framework\TestCase;
 
 class AuctionRepositoryTest extends TestCase
 {
+    private AuctionRepository $repo;
+
     protected function setUp(): void
     {
-        $_SESSION = [];
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE auctions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id INTEGER NOT NULL,
+            item_name TEXT NOT NULL,
+            min_bid INTEGER NOT NULL,
+            ends_at TEXT NOT NULL,
+            status TEXT NOT NULL,
+            winner_user_id INTEGER NULL,
+            winning_bid INTEGER NULL,
+            created_at TEXT NOT NULL,
+            closed_at TEXT NULL
+        )');
+        $this->repo = new AuctionRepository($pdo);
     }
 
     public function testCreateAndUpdateAuction(): void
     {
-        $repo = new AuctionRepository();
-        $auction = $repo->create('Sword', 1, 5, 60);
+        $auction = $this->repo->create('Sword', 1, 5, 60);
         $this->assertSame('Sword', $auction['item']);
-        $repo->setMinBid($auction['id'], 10);
-        $repo->setEndTime($auction['id'], time() + 120);
-        $repo->setWinner($auction['id'], 'Alice');
-        $repo->close($auction['id']);
-        $repo->delete($auction['id']);
-        $this->assertNull($repo->find($auction['id']));
+        $this->repo->setMinBid($auction['id'], 10);
+        $this->repo->setEndTime($auction['id'], time() + 120);
+        $this->repo->setWinner($auction['id'], 2);
+        $this->repo->close($auction['id']);
+        $this->repo->delete($auction['id']);
+        $this->assertNull($this->repo->find($auction['id']));
     }
 }

--- a/tests/Unit/EventRepositoryTest.php
+++ b/tests/Unit/EventRepositoryTest.php
@@ -2,22 +2,36 @@
 namespace Tests\Unit;
 
 use App\Repositories\EventRepository;
+use PDO;
 use PHPUnit\Framework\TestCase;
 
 class EventRepositoryTest extends TestCase
 {
+    private EventRepository $repo;
+
     protected function setUp(): void
     {
-        $_SESSION = [];
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            event_type_id INTEGER NOT NULL DEFAULT 1,
+            occurred_at TEXT NOT NULL,
+            notes TEXT NULL,
+            dropped_item TEXT NULL,
+            created_by INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL
+        )');
+        $this->repo = new EventRepository($pdo);
     }
 
     public function testCreateAndDeleteEvent(): void
     {
-        $repo = new EventRepository();
-        $event = $repo->create('Raid', '2024-01-01', ['Sword', 'Shield']);
+        $event = $this->repo->create('Raid', '2024-01-01', ['Sword', 'Shield']);
         $this->assertSame('Raid', $event['name']);
-        $repo->delete($event['id']);
-        $ids = array_column($repo->all(), 'id');
+        $this->repo->delete($event['id']);
+        $ids = array_column($this->repo->all(), 'id');
         $this->assertNotContains($event['id'], $ids);
     }
 }


### PR DESCRIPTION
## Summary
- pull event listings from `events` table instead of placeholder session data
- read and update auctions via the `auctions` table to show only real auctions
- adjust unit tests to exercise new database-backed repositories

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a6eeea30cc832c9c27c81fec92b653